### PR TITLE
Fix deprecated castShadows

### DIFF
--- a/Cardboard/Editor.meta
+++ b/Cardboard/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 7c98c5ffcf17d49fc88af4e1d260f2cb
+folderAsset: yes
+timeCreated: 1425416265
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Editor/CardboardEditor.cs
+++ b/Cardboard/Editor/CardboardEditor.cs
@@ -1,0 +1,82 @@
+// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections;
+using UnityEditor;
+using UnityEngine;
+
+[CustomEditor(typeof(Cardboard))]
+public class CardboardEditor : Editor {
+  GUIContent tapIsTriggerLabel = new GUIContent("Tap Is Trigger",
+    "Allow screen taps and mouse clicks to emulate the magnet trigger.");
+
+  GUIContent alignmentMarkerLabel = new GUIContent("Alignment Marker",
+    "Whether to draw the alignment marker. The marker is a vertical line that splits " +
+    "the viewport in half, designed to help users align the screen with the Cardboard.");
+
+  GUIContent settingsButtonLabel = new GUIContent("Settings Button",
+    "Whether to draw the settings button. The settings button opens the " +
+    "Google Cardboard app to allow the user to  configure their individual " +
+    "settings and Cardboard headset parameters.");
+
+  GUIContent vrModeEnabledLabel = new GUIContent("VR Mode Enabled",
+    "Explicitly set whether VR mode is enabled.  Clears the Auto Enable VR setting.");
+
+  GUIContent backButtonExitsAppLabel = new GUIContent("Back Button Exits App",
+    "Whether tapping the back button exits the app.");
+
+  public override void OnInspectorGUI() {
+    GUI.changed = false;
+
+    DrawDefaultInspector();
+
+    Cardboard cardboard = (Cardboard)target;
+
+    bool newTapIsTrigger = EditorGUILayout.Toggle(tapIsTriggerLabel, cardboard.TapIsTrigger);
+    if (newTapIsTrigger != cardboard.TapIsTrigger) {
+        cardboard.TapIsTrigger = newTapIsTrigger;
+    }
+
+    bool newEnableAlignmentMarkder =
+      EditorGUILayout.Toggle(alignmentMarkerLabel, cardboard.EnableAlignmentMarker);
+    if (newEnableAlignmentMarkder != cardboard.EnableAlignmentMarker) {
+      cardboard.EnableAlignmentMarker = newEnableAlignmentMarkder;
+    }
+
+    bool newEnableSettingsButton =
+      EditorGUILayout.Toggle(settingsButtonLabel, cardboard.EnableSettingsButton);
+    if (newEnableSettingsButton != cardboard.EnableSettingsButton) {
+      cardboard.EnableSettingsButton = newEnableSettingsButton;
+    }
+
+    bool newVRModeEnabled = EditorGUILayout.Toggle(vrModeEnabledLabel, cardboard.VRModeEnabled);
+    if (newVRModeEnabled != cardboard.VRModeEnabled) {
+      cardboard.VRModeEnabled = newVRModeEnabled;
+    }
+
+    cardboard.BackButtonExitsApp =
+      EditorGUILayout.Toggle(backButtonExitsAppLabel, cardboard.BackButtonExitsApp);
+
+    if (GUI.changed) {
+      EditorUtility.SetDirty(cardboard);
+    }
+
+    if (EditorApplication.isPlaying) {
+      bool newInCardboard = EditorGUILayout.Toggle("Is In Cardboard", cardboard.InCardboard);
+      if (newInCardboard != cardboard.InCardboard) {
+        cardboard.SetInCardboard(newInCardboard); // Takes effect at end of frame.
+      }
+    }
+  }
+}

--- a/Cardboard/Editor/CardboardEditor.cs
+++ b/Cardboard/Editor/CardboardEditor.cs
@@ -37,7 +37,7 @@ public class CardboardEditor : Editor {
     "Whether tapping the back button exits the app.");
 
   public override void OnInspectorGUI() {
-    GUI.changed = false;
+    UnityEngine.GUI.changed = false;
 
     DrawDefaultInspector();
 
@@ -68,7 +68,7 @@ public class CardboardEditor : Editor {
     cardboard.BackButtonExitsApp =
       EditorGUILayout.Toggle(backButtonExitsAppLabel, cardboard.BackButtonExitsApp);
 
-    if (GUI.changed) {
+	if (UnityEngine.GUI.changed) {
       EditorUtility.SetDirty(cardboard);
     }
 

--- a/Cardboard/Editor/CardboardEditor.cs.meta
+++ b/Cardboard/Editor/CardboardEditor.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: ed7a9fc9a5d44422b99d0a825d3cbf1e
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Editor/StereoControllerEditor.cs
+++ b/Cardboard/Editor/StereoControllerEditor.cs
@@ -1,0 +1,116 @@
+﻿// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using UnityEngine;
+using UnityEditor;
+using System.Collections;
+using System.Linq;
+
+[CustomEditor(typeof(StereoController))]
+public class StereoControllerEditor : Editor {
+  // Name of button, and part of "Undo ..." message.
+  public const string ACTION_NAME = "Update Stereo Cameras";
+
+  private GUIContent updateButton =
+    new GUIContent(ACTION_NAME, "Copy all Camera settings to the stereo cameras.");
+
+  public override void OnInspectorGUI() {
+    DrawDefaultInspector();
+    GUILayout.BeginHorizontal(GUILayout.ExpandHeight(false));
+    GUILayout.FlexibleSpace();
+    if (GUILayout.Button(updateButton, GUILayout.ExpandWidth(false))) {
+      var controller = (StereoController)target;
+      DoUpdateStereoCameras(controller.gameObject);
+    }
+    GUILayout.FlexibleSpace();
+    GUILayout.EndHorizontal();
+  }
+
+  [MenuItem("Component/Cardboard/Update Stereo Cameras", true)]
+  public static bool CanUpdateStereoCameras() {
+    // Make sure all selected items have valid cameras.
+    return Selection.gameObjects.Where(go => CanUpdateStereoCameras(go)).Count()
+        == Selection.gameObjects.Length;
+  }
+
+  [MenuItem("CONTEXT/Camera/Update Stereo Cameras", true)]
+  public static bool CanUpdateStereoCamerasContext(MenuCommand command) {
+    var camera = (Camera)command.context;
+    return CanUpdateStereoCameras(camera.gameObject);
+  }
+
+  [MenuItem("Component/Cardboard/Update Stereo Cameras")]
+  public static void UpdateStereoCameras() {
+    foreach (var go in Selection.gameObjects) {
+      DoUpdateStereoCameras(go);
+    }
+  }
+
+  [MenuItem("CONTEXT/Camera/Update Stereo Cameras")]
+  public static void UpdateStereoCamerasContext(MenuCommand command) {
+    var camera = (Camera)command.context;
+    DoUpdateStereoCameras(camera.gameObject);
+  }
+
+  private static bool CanUpdateStereoCameras(GameObject go) {
+    return go != null &&
+           go.hideFlags == HideFlags.None &&
+           go.GetComponent<Camera>() != null &&
+           go.GetComponent<CardboardEye>() == null;
+  }
+
+  private static void DoUpdateStereoCameras(GameObject go) {
+    // Make sure there is a StereoController.
+    var controller = go.GetComponent<StereoController>();
+    if (controller == null) {
+      controller = go.AddComponent<StereoController>();
+      Undo.RegisterCreatedObjectUndo(controller, ACTION_NAME);
+    }
+
+    // Remember current state of stereo rig.
+    bool hadSkybox = go.GetComponent<SkyboxMesh>() != null;
+    bool hadHead = controller.Head != null;
+    bool hadEyes = controller.Eyes.Length > 0;
+
+    controller.AddStereoRig();
+
+    // Support undo...
+
+    // Skybox mesh.  Deletes it if camera is not Main.
+    var skybox = go.GetComponent<SkyboxMesh>();
+    if (skybox != null) {
+      if (!hadSkybox) {
+        Undo.RegisterCreatedObjectUndo(skybox, ACTION_NAME);
+      } else if (go.GetComponent<Camera>().tag != "MainCamera") {
+        Undo.DestroyObjectImmediate(skybox);
+      }
+    }
+
+    // Head.
+    var head = go.GetComponent<CardboardHead>();
+    if (head != null && !hadHead) {
+        Undo.RegisterCreatedObjectUndo(head, ACTION_NAME);
+    }
+
+    // Eyes. Synchronizes them with controller's camera too.
+    foreach (var eye in controller.Eyes) {
+      if (!hadEyes) {
+        Undo.RegisterCreatedObjectUndo(eye.gameObject, ACTION_NAME);
+      } else {
+        Undo.RecordObject(eye.GetComponent<Camera>(), ACTION_NAME);
+        eye.CopyCameraAndMakeSideBySide(controller);
+      }
+    }
+  }
+}

--- a/Cardboard/Editor/StereoControllerEditor.cs.meta
+++ b/Cardboard/Editor/StereoControllerEditor.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 05c5a7cf1f7ca4a0db9fef203f559380
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/LICENSE
+++ b/Cardboard/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Cardboard/LICENSE.meta
+++ b/Cardboard/LICENSE.meta
@@ -1,0 +1,6 @@
+fileFormatVersion: 2
+guid: 0ae37b2426f844468ab02f411263ae0d
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Prefabs.meta
+++ b/Cardboard/Prefabs.meta
@@ -1,0 +1,5 @@
+fileFormatVersion: 2
+guid: 80e6cdf429de247a792161c31b9b2ce2
+folderAsset: yes
+DefaultImporter:
+  userData: 

--- a/Cardboard/Prefabs/CardboardAdapter.prefab
+++ b/Cardboard/Prefabs/CardboardAdapter.prefab
@@ -1,0 +1,235 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 400000}
+  - 20: {fileID: 2000000}
+  - 92: {fileID: 9200000}
+  - 124: {fileID: 12400000}
+  - 114: {fileID: 11400000}
+  m_Layer: 0
+  m_Name: Camera Right
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &100002
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 400002}
+  - 20: {fileID: 2000002}
+  - 92: {fileID: 9200002}
+  - 124: {fileID: 12400002}
+  - 114: {fileID: 11400002}
+  m_Layer: 0
+  m_Name: Camera Left
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &100004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 400004}
+  - 114: {fileID: 11400004}
+  m_Layer: 0
+  m_Name: CardboardAdapter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &400000
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: .0299999993, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 400004}
+  m_RootOrder: 0
+--- !u!4 &400002
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -.0299999993, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 400004}
+  m_RootOrder: 1
+--- !u!4 &400004
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100004}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 400000}
+  - {fileID: 400002}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!20 &2000000
+Camera:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: .192156866, g: .301960796, b: .474509805, a: .0196078438}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: .5
+    y: 0
+    width: .5
+    height: 1
+  near clip plane: .300000012
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: .0219999999
+--- !u!20 &2000002
+Camera:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: .192156866, g: .301960796, b: .474509805, a: .0196078438}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: .5
+    height: 1
+  near clip plane: .300000012
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: .0219999999
+--- !u!92 &9200000
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+--- !u!92 &9200002
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_Enabled: 1
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c9cfdc6c389e2742aa40f991195d828, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  eye: 1
+--- !u!114 &11400002
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c9cfdc6c389e2742aa40f991195d828, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  eye: 0
+--- !u!114 &11400004
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100004}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1578549c7fcc4f6fa1b063992091672, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 0}
+  updateEarly: 0
+--- !u!124 &12400000
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+--- !u!124 &12400002
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_Enabled: 1
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 100004}
+  m_IsPrefabParent: 1
+  m_IsExploded: 1

--- a/Cardboard/Prefabs/CardboardAdapter.prefab.meta
+++ b/Cardboard/Prefabs/CardboardAdapter.prefab.meta
@@ -1,0 +1,6 @@
+fileFormatVersion: 2
+guid: e2caa624e4c89492dbb6df8d93901ef9
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Prefabs/CardboardGUI.prefab
+++ b/Cardboard/Prefabs/CardboardGUI.prefab
@@ -1,0 +1,159 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 400000}
+  - 114: {fileID: 11400000}
+  - 114: {fileID: 11400004}
+  m_Layer: 5
+  m_Name: CardboardGUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &100002
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 400002}
+  - 33: {fileID: 3300000}
+  - 23: {fileID: 2300000}
+  - 64: {fileID: 6400000}
+  - 114: {fileID: 11400002}
+  m_Layer: 5
+  m_Name: GUIScreen
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &400000
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 400002}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!4 &400002
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 400000}
+  m_RootOrder: 0
+--- !u!23 &2300000
+Renderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_LightmapIndex: 255
+  m_LightmapTilingOffset: {x: 1, y: 1, z: 0, w: 0}
+  m_Materials:
+  - {fileID: 10302, guid: 0000000000000000f000000000000000, type: 0}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_UseLightProbes: 0
+  m_LightProbeAnchor: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+--- !u!33 &3300000
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!64 &6400000
+MeshCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_SmoothSphereCollisions: 0
+  m_Convex: 0
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 46945e3ed78924bdea8171f8de038346, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  background: {r: 0, g: 0, b: 0, a: 0}
+--- !u!114 &11400002
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b076d97177f8c446c97ffb15e968d1af, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!114 &11400004
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f06724eec91fb4704a525c71a8e8deea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  head: {fileID: 0}
+  pointerImage: {fileID: 2800000, guid: 53a9e781f887f46e1817489bff4b661d, type: 3}
+  pointerSize: {x: 16, y: 16}
+  pointerSpot: {x: 8, y: 8}
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 100000}
+  m_IsPrefabParent: 1
+  m_IsExploded: 1

--- a/Cardboard/Prefabs/CardboardGUI.prefab.meta
+++ b/Cardboard/Prefabs/CardboardGUI.prefab.meta
@@ -1,0 +1,6 @@
+fileFormatVersion: 2
+guid: dcd8898a5b8c54c59a1b18bcf72ebd37
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Prefabs/CardboardHead.prefab
+++ b/Cardboard/Prefabs/CardboardHead.prefab
@@ -1,0 +1,341 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 400000}
+  - 20: {fileID: 2000000}
+  - 92: {fileID: 9200000}
+  - 124: {fileID: 12400000}
+  - 114: {fileID: 11400000}
+  m_Layer: 0
+  m_Name: Camera Right
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &100002
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 400002}
+  - 20: {fileID: 2000002}
+  - 92: {fileID: 9200002}
+  - 124: {fileID: 12400002}
+  - 114: {fileID: 11400002}
+  m_Layer: 0
+  m_Name: Camera Left
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &100004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 400004}
+  - 114: {fileID: 11400004}
+  m_Layer: 0
+  m_Name: CardboardHead
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &100006
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 400006}
+  - 20: {fileID: 2000004}
+  - 124: {fileID: 12400004}
+  - 92: {fileID: 9200004}
+  - 81: {fileID: 8100000}
+  - 114: {fileID: 11400006}
+  m_Layer: 0
+  m_Name: Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &400000
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: .0299999993, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 400006}
+  m_RootOrder: 1
+--- !u!4 &400002
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -.0299999993, y: -0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 400006}
+  m_RootOrder: 0
+--- !u!4 &400004
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100004}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 400006}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!4 &400006
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100006}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 400002}
+  - {fileID: 400000}
+  m_Father: {fileID: 400004}
+  m_RootOrder: 0
+--- !u!20 &2000000
+Camera:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: .192156866, g: .301960796, b: .474509805, a: .0196078438}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: .5
+    y: 0
+    width: .5
+    height: 1
+  near clip plane: .300000012
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: .0219999999
+--- !u!20 &2000002
+Camera:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: .192156866, g: .301960796, b: .474509805, a: .0196078438}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: .5
+    height: 1
+  near clip plane: .300000012
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: .0219999999
+--- !u!20 &2000004
+Camera:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100006}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: .192156866, g: .301960796, b: .474509805, a: .0196078438}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: .300000012
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: .0219999999
+--- !u!81 &8100000
+AudioListener:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100006}
+  m_Enabled: 1
+--- !u!92 &9200000
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+--- !u!92 &9200002
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_Enabled: 1
+--- !u!92 &9200004
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100006}
+  m_Enabled: 1
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c9cfdc6c389e2742aa40f991195d828, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  eye: 1
+--- !u!114 &11400002
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c9cfdc6c389e2742aa40f991195d828, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  eye: 0
+--- !u!114 &11400004
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100004}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1578549c7fcc4f6fa1b063992091672, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 0}
+  updateEarly: 0
+--- !u!114 &11400006
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100006}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6788e8e1b3f7447db6657ef0959d3ce, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  directRender: 1
+  stereoMultiplier: 1
+  matchMonoFOV: 0
+  centerOfInterest: {fileID: 0}
+  radiusOfInterest: 0
+  checkStereoComfort: 1
+  screenParallax: 0
+  stereoPaddingX: 0
+  stereoPaddingY: 0
+--- !u!124 &12400000
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+--- !u!124 &12400002
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_Enabled: 1
+--- !u!124 &12400004
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100006}
+  m_Enabled: 1
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 100004}
+  m_IsPrefabParent: 1
+  m_IsExploded: 1

--- a/Cardboard/Prefabs/CardboardHead.prefab.meta
+++ b/Cardboard/Prefabs/CardboardHead.prefab.meta
@@ -1,0 +1,6 @@
+fileFormatVersion: 2
+guid: 691bf3e71b387435bb6304e28d671b2f
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Prefabs/CardboardMain.prefab
+++ b/Cardboard/Prefabs/CardboardMain.prefab
@@ -1,0 +1,400 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 400000}
+  - 20: {fileID: 2000000}
+  - 92: {fileID: 9200000}
+  - 124: {fileID: 12400000}
+  - 114: {fileID: 11400002}
+  m_Layer: 0
+  m_Name: Main Camera Right
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &100002
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 400002}
+  - 20: {fileID: 2000002}
+  - 92: {fileID: 9200002}
+  - 124: {fileID: 12400002}
+  - 114: {fileID: 11400004}
+  m_Layer: 0
+  m_Name: Main Camera Left
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &100004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 400004}
+  - 114: {fileID: 11400012}
+  m_Layer: 0
+  m_Name: CardboardMain
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &100006
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 400006}
+  - 20: {fileID: 2000004}
+  - 124: {fileID: 12400004}
+  - 92: {fileID: 9200004}
+  - 81: {fileID: 8100000}
+  - 114: {fileID: 11400006}
+  - 114: {fileID: 11400000}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &100008
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 400008}
+  - 114: {fileID: 11400008}
+  m_Layer: 0
+  m_Name: Head
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &400000
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: .0299999993, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 400006}
+  m_RootOrder: 1
+--- !u!4 &400002
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -.0299999993, y: -0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 400006}
+  m_RootOrder: 0
+--- !u!4 &400004
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100004}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 400008}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!4 &400006
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100006}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 400002}
+  - {fileID: 400000}
+  m_Father: {fileID: 400008}
+  m_RootOrder: 0
+--- !u!4 &400008
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100008}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 400006}
+  m_Father: {fileID: 400004}
+  m_RootOrder: 0
+--- !u!20 &2000000
+Camera:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: .192156866, g: .301960796, b: .474509805, a: .0196078438}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: .5
+    y: 0
+    width: .5
+    height: 1
+  near clip plane: .300000012
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: .0219999999
+--- !u!20 &2000002
+Camera:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: .192156866, g: .301960796, b: .474509805, a: .0196078438}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: .5
+    height: 1
+  near clip plane: .300000012
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: .0219999999
+--- !u!20 &2000004
+Camera:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100006}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: .192156866, g: .301960796, b: .474509805, a: .0196078438}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: .300000012
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: .0219999999
+--- !u!81 &8100000
+AudioListener:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100006}
+  m_Enabled: 1
+--- !u!92 &9200000
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+--- !u!92 &9200002
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_Enabled: 1
+--- !u!92 &9200004
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100006}
+  m_Enabled: 1
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100006}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1842d86d69a644a109b06ba5a5935819, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  segments: 32
+  shape: 0
+--- !u!114 &11400002
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c9cfdc6c389e2742aa40f991195d828, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  eye: 1
+--- !u!114 &11400004
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c9cfdc6c389e2742aa40f991195d828, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  eye: 0
+--- !u!114 &11400006
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100006}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6788e8e1b3f7447db6657ef0959d3ce, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  directRender: 1
+  stereoMultiplier: 1
+  matchMonoFOV: 0
+  centerOfInterest: {fileID: 0}
+  radiusOfInterest: 0
+  checkStereoComfort: 1
+  screenParallax: 0
+  stereoPaddingX: 0
+  stereoPaddingY: 0
+--- !u!114 &11400008
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100008}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1578549c7fcc4f6fa1b063992091672, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 0}
+  updateEarly: 0
+--- !u!114 &11400012
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100004}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a40b544b8c3553c40852ae7ad35a9343, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  vrModeEnabled: 1
+  enableAlignmentMarker: 1
+  enableSettingsButton: 1
+  tapIsTrigger: 0
+  autoUntiltHead: 1
+--- !u!124 &12400000
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+--- !u!124 &12400002
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100002}
+  m_Enabled: 1
+--- !u!124 &12400004
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100006}
+  m_Enabled: 1
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 100004}
+  m_IsPrefabParent: 1
+  m_IsExploded: 1

--- a/Cardboard/Prefabs/CardboardMain.prefab.meta
+++ b/Cardboard/Prefabs/CardboardMain.prefab.meta
@@ -1,0 +1,6 @@
+fileFormatVersion: 2
+guid: b8b03d395f5734e98af91ccf44f9bf47
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/README
+++ b/Cardboard/README
@@ -1,0 +1,7 @@
+Cardboard SDK for Unity
+
+This SDK provides Android developers with the easiest way to add
+Cardboard VR Toolkit support to their Unity projects.
+
+Please visit https://developers.google.com/cardboard/unity for the latest
+version of this SDK.

--- a/Cardboard/README.meta
+++ b/Cardboard/README.meta
@@ -1,0 +1,6 @@
+fileFormatVersion: 2
+guid: de961e46abe24453a81bf1c8576885b3
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Resources.meta
+++ b/Cardboard/Resources.meta
@@ -1,0 +1,5 @@
+fileFormatVersion: 2
+guid: c5cce34e4c5954a0b8bdf30ff6a18430
+folderAsset: yes
+DefaultImporter:
+  userData: 

--- a/Cardboard/Resources/GUIScreen.shader
+++ b/Cardboard/Resources/GUIScreen.shader
@@ -1,0 +1,28 @@
+﻿// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Shader "Cardboard/GUIScreen" {
+  Properties {
+    _MainTex ("Texture", 2D) = "white" {}
+  }
+  SubShader {
+    Tags { "Queue" = "Overlay" }
+    Lighting Off Cull Off Fog { Mode Off } ZTest Always ZWrite Off
+    Blend SrcAlpha OneMinusSrcAlpha
+    Pass {
+      SetTexture [_MainTex] { combine texture double }
+    }
+  }
+  Fallback Off
+}

--- a/Cardboard/Resources/GUIScreen.shader.meta
+++ b/Cardboard/Resources/GUIScreen.shader.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bc707ac7319ae4f148a8ed3cbd156e4a
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Resources/RadialUndistortionEffect.shader
+++ b/Cardboard/Resources/RadialUndistortionEffect.shader
@@ -1,0 +1,73 @@
+﻿// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Shader "Cardboard/Radial Undistortion" {
+
+  Properties {
+    _MainTex ("Base (RGB)", 2D) = "white" {}
+  }
+
+  SubShader {
+    Tags { "RenderType" = "Opaque" }
+    LOD 150
+
+    Pass {
+      CGPROGRAM
+      #include "UnityCG.cginc"
+      #pragma vertex vert
+      #pragma fragment frag
+
+      struct v2f {
+        float4 vertex  : SV_POSITION;
+        half2 texcoord : TEXCOORD0;
+      };
+
+      sampler2D _MainTex;
+      float4    _MainTex_ST;
+
+      float4 _Distortion;   // Radial distortion coefficients.
+      float4 _Projection;   // Bits of the lens-affected projection matrix.
+      float4 _Unprojection; // Bits of the no-lens projection matrix.
+
+      v2f vert (appdata_base v) {
+        // This is totally standard code, including the _MainTex transform.
+        v2f o;
+        o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+        o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
+        return o;
+      }
+
+      fixed4 frag (v2f i) : SV_Target {
+        // i.texcoord refers to the onscreen pixel we want to color.  We have to find the
+        // corresponding pixel in the rendered texture, which means going through the lens'
+        // distortion transformation.
+        // First: go from these onscreen texture coordinates back into camera space, using parts
+        // of the projection matrix for the "no lens" frustum.  (We don't need the whole matrix
+        // because we don't care about Z.)
+        float2 tex = (i.texcoord + _Unprojection.zw) / _Unprojection.xy;
+        // Second: Radially distort the vector according to the lens' coefficients (pincushion).
+        float r2 = dot(tex, tex);
+        tex *= 1 + (_Distortion.x + _Distortion.y * r2) * r2;
+        // Reproject the vector into the lens-affected frustum to get the texture coordinates
+        // to look up.
+        tex = tex * _Projection.xy - _Projection.zw;
+        // Get the color.  But the coordinates may be out of bounds, so check for that.
+        fixed4 col = all(tex >= 0) && all(tex <= 1) ? tex2D(_MainTex, tex) : fixed4(0,0,0,1);
+        return col;
+      }
+      ENDCG
+    }
+  }
+
+}

--- a/Cardboard/Resources/RadialUndistortionEffect.shader.meta
+++ b/Cardboard/Resources/RadialUndistortionEffect.shader.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 666b803d917634f0fa8bc0cbfbbf1604
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Resources/SkyboxMesh.shader
+++ b/Cardboard/Resources/SkyboxMesh.shader
@@ -1,0 +1,48 @@
+﻿// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Original code by Nora
+// http://stereoarts.jp
+//
+// Retrieved from:
+// https://developer.oculusvr.com/forums/viewtopic.php?f=37&t=844#p28982
+
+Shader "Cardboard/SkyboxMesh" {
+  Properties {
+    _Color ("Main Color", Color) = (1,1,1,1)
+    _MainTex ("Texture", 2D) = "white" {}
+  }
+  Category {
+   Tags { "Queue"="Background" }
+    ZWrite Off
+    Lighting Off
+    Fog {Mode Off}
+    BindChannels {
+      Bind "Color", color
+      Bind "Vertex", vertex
+      Bind "TexCoord", texcoord
+    }
+    SubShader {
+      Pass {
+        SetTexture [_MainTex] {
+          Combine texture
+        }
+        SetTexture [_MainTex] {
+          constantColor [_Color]
+          combine previous * constant
+        }
+      }
+    }
+  }
+}

--- a/Cardboard/Resources/SkyboxMesh.shader.meta
+++ b/Cardboard/Resources/SkyboxMesh.shader.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c22be0408cec74248b876d70c820053c
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Scripts.meta
+++ b/Cardboard/Scripts.meta
@@ -1,0 +1,5 @@
+fileFormatVersion: 2
+guid: 5f01aa5c8e7de4973aa7785e6b4dc993
+folderAsset: yes
+DefaultImporter:
+  userData: 

--- a/Cardboard/Scripts/Cardboard.cs
+++ b/Cardboard/Scripts/Cardboard.cs
@@ -1,0 +1,821 @@
+﻿// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if UNITY_ANDROID && !UNITY_EDITOR
+#define ANDROID_DEVICE
+#endif
+
+using UnityEngine;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+
+// A Cardboard object serves as the bridge between the C# and the Java/native
+// components of the plugin.
+//
+// On each frame, it's responsible for
+//  - Reading the current head orientation and eye transforms from the Java
+//    vrtoolkit
+//  - Triggering the native (C++) UnityRenderEvent callback at the end of the
+//    frame.  This sends the texture containing the latest frame that Unity
+//    rendered into the Java vrtoolkit to be corrected for lens distortion and
+//    displayed on the device.
+public class Cardboard : MonoBehaviour {
+  // Distinguish the two stereo eyes.
+  public enum Eye {
+    Left,
+    Right
+  }
+
+#if UNITY_IPHONE && !UNITY_EDITOR
+  [DllImport("__Internal")]
+#else
+  [DllImport("RenderingPlugin")]
+#endif
+  private static extern void InitFromUnity(int textureID);
+
+  // The singleton instance of the Cardboard class.
+  private static Cardboard sdk = null;
+
+  public static Cardboard SDK {
+    get {
+      if (sdk == null) {
+        Debug.Log("Creating Cardboard object");
+        var go = new GameObject("Cardboard");
+        sdk = go.AddComponent<Cardboard>();
+        go.transform.localPosition = Vector3.zero;
+      }
+      return sdk;
+    }
+  }
+
+  [Tooltip("Whether distortion correction is performed by the native plugin code.")]
+  public bool nativeDistortionCorrection = true;
+
+  // Whether VR-mode is enabled.
+  public bool VRModeEnabled {
+    get { return vrModeEnabled; }
+    set {
+      vrModeEnabled = value;
+    }
+  }
+
+  [SerializeField]
+  [HideInInspector]
+  private bool vrModeEnabled = true;
+
+  // Whether to draw the alignment marker. The marker is a vertical line that
+  // splits the viewport in half, designed to help users align the screen with the Cardboard.
+  public bool EnableAlignmentMarker {
+      get { return enableAlignmentMarker; }
+      set {
+          enableAlignmentMarker = value;
+#if ANDROID_DEVICE
+          CallActivityMethod("setAlignmentMarkerEnabled", enableAlignmentMarker);
+#endif
+      }
+  }
+
+  [SerializeField]
+  [HideInInspector]
+  private bool enableAlignmentMarker = true;
+
+  // Whether to draw the settings button. The settings button opens the Google
+  // Cardboard app to allow the user to  configure their individual settings and Cardboard
+  // headset parameters
+  public bool EnableSettingsButton {
+      get { return enableSettingsButton; }
+      set {
+          enableSettingsButton = value;
+#if ANDROID_DEVICE
+          CallActivityMethod("setSettingsButtonEnabled", enableSettingsButton);
+#endif
+      }
+  }
+
+  [SerializeField]
+  [HideInInspector]
+  private bool enableSettingsButton = true;
+
+  // Whether screen taps are converted to Cardboard trigger events.
+  public bool TapIsTrigger {
+    get { return tapIsTrigger; }
+    set {
+      tapIsTrigger = value;
+#if ANDROID_DEVICE
+      CallActivityMethod("setConvertTapIntoTrigger", tapIsTrigger);
+#endif
+    }
+  }
+
+  [SerializeField]
+  [HideInInspector]
+  private bool tapIsTrigger = false;
+
+  // Whether the back button exits the application.
+  public bool BackButtonExitsApp {
+    get { return backButtonExitsApp; }
+    set {
+      backButtonExitsApp = value;
+    }
+  }
+
+  [SerializeField]
+  [HideInInspector]
+  private bool backButtonExitsApp = true;
+
+  // Whether the device is in a Cardboard.
+  public bool InCardboard { get; private set; }
+
+  // Defer updating InCardboard till end of frame.
+  private bool newInCardboard;
+
+#if UNITY_EDITOR
+  // Helper for the custom editor script.
+  public void SetInCardboard(bool value) {
+      newInCardboard = value; // Takes effect at end of frame.
+  }
+#endif
+
+  // Whether the Cardboard trigger (i.e. magnet) was pulled.
+  // True for exactly one frame (between 2 EndOfFrames) on each pull.
+  public bool CardboardTriggered { get; private set; }
+
+  // Next frame's value of CardboardTriggered.
+  private bool newCardboardTriggered = false;
+
+  // The texture that Unity renders the scene to. This is sent to the plugin,
+  // which renders it to screen, correcting for lens distortion.
+  public RenderTexture StereoScreen {
+    get {
+      // Don't need it except for distortion correction.
+      if (!nativeDistortionCorrection || !vrModeEnabled) {
+        return null;
+      }
+      if (stereoScreen == null) {
+        CreateStereoScreen();
+      }
+      return stereoScreen;
+    }
+  }
+
+  private RenderTexture stereoScreen;
+
+  // Describes the current device, including phone screen.
+  public CardboardProfile Profile { get; private set; }
+
+  // Transform from body to head.
+  public Matrix4x4 HeadView { get { return headView; } }
+  private Matrix4x4 headView;
+
+  // Transform from body to head as a Quaternion.
+  public Quaternion HeadRotation { get; private set; }
+
+  // The transformation from head to eye.
+  public Matrix4x4 EyeView(Cardboard.Eye eye) {
+      return eye == Cardboard.Eye.Left ? leftEyeView : rightEyeView;
+  }
+  private Matrix4x4 leftEyeView;
+  private Matrix4x4 rightEyeView;
+
+  // The projection matrix for a given eye.  This encodes the field of view,
+  // IPD, and other parameters configured by the SDK.
+  public Matrix4x4 Projection(Cardboard.Eye eye) {
+      return eye == Cardboard.Eye.Left ? leftEyeProj : rightEyeProj;
+  }
+  private Matrix4x4 leftEyeProj;
+  private Matrix4x4 rightEyeProj;
+
+  // The undistorted projection matrix for a given eye.  This encodes the field of
+  // view, IPD, and other parameters configured by the SDK, but ignores the distortion
+  // caused by the lenses.
+  public Matrix4x4 UndistortedProjection(Cardboard.Eye eye) {
+      return eye == Cardboard.Eye.Left ? leftEyeUndistortedProj : rightEyeUndistortedProj;
+  }
+  private Matrix4x4 leftEyeUndistortedProj;
+  private Matrix4x4 rightEyeUndistortedProj;
+
+  // Local transformations of eyes relative to head.
+  public Vector3 EyeOffset(Cardboard.Eye eye) {
+      return eye == Cardboard.Eye.Left ? leftEyeOffset : rightEyeOffset;
+  }
+  private Vector3 leftEyeOffset;
+  private Vector3 rightEyeOffset;
+
+  // The screen-space rectangle each eye should render into.
+  public Rect EyeRect(Cardboard.Eye eye) {
+      return eye == Cardboard.Eye.Left ? leftEyeRect : rightEyeRect;
+  }
+  private Rect leftEyeRect;
+  private Rect rightEyeRect;
+
+  // Minimum distance from the user that an object may be viewed in stereo
+  // without eye strain, in meters.  The stereo eye separation should
+  // be scaled down if the "center of interest" is closer than this.  This
+  // will set a lower limit on the disparity of the COI between the two eyes.
+  // See CardboardEye.OnPreCull().
+  public float MinimumComfortDistance {
+      get {
+          return 1.0f;
+      }
+  }
+
+  // Maximum distance from the user that an object may be viewed in
+  // stereo without eye strain, in meters.  The stereo eye separation
+  // should be scaled up of if the COI is farther than this.  This will
+  // set an upper limit on the disparity of the COI between the two eyes.
+  // See CardboardEye.OnPreCull().
+  // Note: For HMDs with optics that focus at infinity there really isn't a
+  // maximum distance, so this number can be set to "really really big".
+  public float MaximumComfortDistance {
+      get {
+          return 100000f;  // i.e. really really big.
+      }
+  }
+
+  // Only call native layer once per frame.
+  private bool updated = false;
+
+  // Configures which Cardboard features are enabled, depending on
+  // the Unity features available.
+  private class Config {
+      // Features.
+      public bool supportsRenderTextures;
+      public bool isAndroid;
+      public bool supportsAndroidRenderEvent;
+      public bool isAtLeastUnity4_5;
+
+      // Access to plugin.
+      public bool canAccessActivity = false;
+
+      // Should be called on main thread.
+      public void initialize() {
+          supportsRenderTextures = SystemInfo.supportsRenderTextures;
+          isAndroid = Application.platform == RuntimePlatform.Android;
+          try {
+              Regex r = new Regex(@"(\d+\.\d+)\..*");
+              string version = r.Replace(Application.unityVersion, "$1");
+              if (new Version(version) >= new Version("4.5")) {
+                  isAtLeastUnity4_5 = true;
+              }
+          } catch {
+              Debug.LogWarning("Unable to determine Unity version from: "
+                      + Application.unityVersion);
+          }
+          supportsAndroidRenderEvent = isAtLeastUnity4_5 && isAndroid;
+      }
+
+      public bool canApplyDistortionCorrection() {
+          return supportsRenderTextures && supportsAndroidRenderEvent
+              && canAccessActivity;
+      }
+
+      public string getDistortionCorrectionDiagnostic() {
+          List<string> causes = new List<string>();
+          if (!isAndroid) {
+              causes.Add("Must be running on Android device");
+          } else if (!canAccessActivity) {
+              causes.Add("Cannot access UnityCardboardActivity. "
+                      + "Verify that the jar is in Assets/Plugins/Android");
+          }
+          if (!supportsRenderTextures) {
+              causes.Add("RenderTexture (Unity Pro feature) is unavailable");
+          }
+          if (!isAtLeastUnity4_5) {
+              causes.Add("Unity 4.5+ is needed for Android UnityPluginEvent");
+          }
+          return String.Join("; ", causes.ToArray());
+      }
+  }
+
+  private Config config = new Config();
+
+  void Awake() {
+      if (sdk == null) {
+          sdk = this;
+      }
+      if (sdk != this) {
+          Debug.LogWarning("Cardboard SDK object should be a singleton.");
+          enabled = false;
+          return;
+      }
+
+      config.initialize();
+
+#if ANDROID_DEVICE
+      ConnectToActivity();
+#endif
+      CreateStereoScreen();
+      UpdateScreenData();
+
+      // Force side-effectful initialization using serialized values.
+      EnableAlignmentMarker = enableAlignmentMarker;
+      EnableSettingsButton = enableSettingsButton;
+      TapIsTrigger = tapIsTrigger;
+
+      InCardboard = newInCardboard = false;
+#if UNITY_EDITOR
+      if (VRModeEnabled && Application.isPlaying) {
+          SetInCardboard(true);
+      }
+#endif
+
+      StartCoroutine("EndOfFrame");
+  }
+
+  void Update() {
+      if (Input.GetKeyDown(KeyCode.Escape) && BackButtonExitsApp) {
+          Application.Quit();
+      }
+#if UNITY_EDITOR
+      SimulateTrigger();
+#endif
+  }
+
+  // Call the SDK (if needed) to get the current transforms for the frame.
+  // This is public so any game script can do this if they need the values.
+  public bool UpdateState() {
+      if (updated) {
+          return true;
+      }
+#if ANDROID_DEVICE
+      UpdateFrameParamsFromActivity();
+#else
+      UpdateSimulatedFrameParams();
+#endif
+      HeadRotation = Quaternion.LookRotation(headView.GetColumn(2), headView.GetColumn(1));
+      leftEyeOffset = leftEyeView.GetColumn(3);
+      rightEyeOffset = rightEyeView.GetColumn(3);
+      updated = true;
+      return true;
+  }
+
+  public void Recenter() {
+#if ANDROID_DEVICE
+      CallActivityMethod("resetHeadTracker");
+#elif UNITY_EDITOR
+      mouseX = mouseY = mouseZ = 0;
+#endif
+  }
+
+  public void UpdateScreenData() {
+#if ANDROID_DEVICE
+    UpdateScreenDataFromActivity();
+#else
+    Profile = CardboardProfile.Default.Clone();
+#endif
+  }
+
+  public void CreateStereoScreen(int x, int y) {
+    if (config.canApplyDistortionCorrection()) {
+      Debug.Log("Creating new cardboard screen texture.");
+      if (stereoScreen != null) {
+        stereoScreen.Release();
+      }
+      stereoScreen = new RenderTexture(x, y, 16, RenderTextureFormat.RGB565);
+      stereoScreen.Create();
+      InitFromUnity(stereoScreen.GetNativeTextureID());
+    } else {
+      stereoScreen = null;
+      if (!Application.isEditor) {
+        nativeDistortionCorrection = false;
+        Debug.LogWarning("Lens distortion-correction disabled. Causes: [" +
+                         config.getDistortionCorrectionDiagnostic() + "]");
+      }
+    }
+  }
+
+  public void CreateStereoScreen() {
+    CreateStereoScreen(Screen.width, Screen.height);
+  }
+
+  // Makes Unity see a mouse click (down + up) at the given pixel.
+  public void InjectMouseClick(int x, int y) {
+#if ANDROID_DEVICE
+      if (downTime == NO_DOWNTIME) {  // If not in the middle of a tap injection.
+          StartCoroutine(DoAndroidScreenTap(x, y));
+      }
+#endif
+  }
+
+  // Makes Unity see a mouse move to the given pixel.
+  public void InjectMouseMove(int x, int y) {
+      if (x == (int)Input.mousePosition.x && y == (int)Input.mousePosition.y) {
+          return;  // Don't send a 0-pixel move.
+      }
+#if ANDROID_DEVICE
+      if (downTime == NO_DOWNTIME) {  // If not in the middle of a tap injection.
+          CallActivityMethod("injectMouseMove", x, y);
+      }
+#endif
+  }
+
+  void OnInsertedIntoCardboardInternal() {
+      newInCardboard = true;
+  }
+
+  void OnRemovedFromCardboardInternal() {
+      newInCardboard = false;
+  }
+
+  void OnCardboardTriggerInternal() {
+      newCardboardTriggered = true;
+  }
+
+  void OnDestroy() {
+      StopCoroutine("EndOfFrame");
+      if (sdk == this) {
+          sdk = null;
+      }
+  }
+
+  // Event IDs supported by our native render plugin.
+  private const int kPerformDistortionCorrection = 1;
+  private const int kDrawCardboardUILayer = 2;
+
+  IEnumerator EndOfFrame() {
+      while (true) {
+          yield return new WaitForEndOfFrame();
+          if (UpdateState() && vrModeEnabled && !Application.isEditor) {
+              GL.InvalidateState();  // necessary for Windows, but not Mac.
+              if (stereoScreen != null && nativeDistortionCorrection) {
+                GL.IssuePluginEvent(kPerformDistortionCorrection);
+              }
+              if (enableSettingsButton || enableAlignmentMarker) {
+                GL.IssuePluginEvent(kDrawCardboardUILayer);
+              }
+          }
+          if (InCardboard != newInCardboard) {
+              UpdateScreenData();
+          }
+          InCardboard = newInCardboard;
+          CardboardTriggered = newCardboardTriggered;
+          newCardboardTriggered = false;
+          updated = false;
+      }
+  }
+
+  private float[] GetLeftEyeVisibleTanAngles() {
+    CardboardProfile p = Profile;
+    // Tan-angles from the max FOV.
+    float fovLeft = (float) Math.Tan(-p.device.maxFOV.outer * Math.PI / 180);
+    float fovTop = (float) Math.Tan(p.device.maxFOV.upper * Math.PI / 180);
+    float fovRight = (float) Math.Tan(p.device.maxFOV.inner * Math.PI / 180);
+    float fovBottom = (float) Math.Tan(-p.device.maxFOV.lower * Math.PI / 180);
+    // Viewport size.
+    float halfWidth = p.screen.width / 4;
+    float halfHeight = p.screen.height / 2;
+    // Viewport center, measured from left lens position.
+    float centerX = p.device.lenses.separation / 2 - halfWidth;
+    float centerY = halfHeight + p.screen.border - p.device.lenses.height;
+    float centerZ = p.device.lenses.screenDistance;
+    // Tan-angles of the viewport edges, as seen through the lens.
+    float screenLeft = p.device.distortion.distort((centerX - halfWidth) / centerZ);
+    float screenTop = p.device.distortion.distort((centerY + halfHeight) / centerZ);
+    float screenRight = p.device.distortion.distort((centerX + halfWidth) / centerZ);
+    float screenBottom = p.device.distortion.distort((centerY - halfWidth) / centerZ);
+    // Compare the two sets of tan-angles and take the value closer to zero on each side.
+    float left = Math.Max(fovLeft, screenLeft);
+    float top = Math.Min(fovTop, screenTop);
+    float right = Math.Min(fovRight, screenRight);
+    float bottom = Math.Max(fovBottom, screenBottom);
+    return new float[] { left, top, right, bottom };
+  }
+
+  private float[] GetLeftEyeNoLensTanAngles() {
+    CardboardProfile p = Profile;
+    // Tan-angles from the max FOV.
+    float fovLeft = p.device.inverse.distort((float)Math.Tan(-p.device.maxFOV.outer * Math.PI / 180));
+    float fovTop = p.device.inverse.distort((float)Math.Tan(p.device.maxFOV.upper * Math.PI / 180));
+    float fovRight = p.device.inverse.distort((float)Math.Tan(p.device.maxFOV.inner * Math.PI / 180));
+    float fovBottom = p.device.inverse.distort((float)Math.Tan(-p.device.maxFOV.lower * Math.PI / 180));
+    // Viewport size.
+    float halfWidth = p.screen.width / 4;
+    float halfHeight = p.screen.height / 2;
+    // Viewport center, measured from left lens position.
+    float centerX = p.device.lenses.separation / 2 - halfWidth;
+    float centerY = halfHeight + p.screen.border - p.device.lenses.height;
+    float centerZ = p.device.lenses.screenDistance;
+    // Tan-angles of the viewport edges, as seen through the lens.
+    float screenLeft = (centerX - halfWidth) / centerZ;
+    float screenTop = (centerY + halfHeight) / centerZ;
+    float screenRight = (centerX + halfWidth) / centerZ;
+    float screenBottom = (centerY - halfWidth) / centerZ;
+    // Compare the two sets of tan-angles and take the value closer to zero on each side.
+    float left = Math.Max(fovLeft, screenLeft);
+    float top = Math.Min(fovTop, screenTop);
+    float right = Math.Min(fovRight, screenRight);
+    float bottom = Math.Max(fovBottom, screenBottom);
+    return new float[] { left, top, right, bottom };
+  }
+
+  private Rect GetLeftEyeVisibleScreenRect(float[] undistortedFrustum = null) {
+    CardboardProfile p = Profile;
+    float dist = p.device.lenses.screenDistance;
+    float eyeX = (p.screen.width - p.device.lenses.separation) / 2;
+    float eyeY = p.device.lenses.height - p.screen.border;
+    float left = (undistortedFrustum[0] * dist + eyeX) / p.screen.width;
+    float top = (undistortedFrustum[1] * dist + eyeY) / p.screen.height;
+    float right = (undistortedFrustum[2] * dist + eyeX) / p.screen.width;
+    float bottom = (undistortedFrustum[3] * dist + eyeY) / p.screen.height;
+    return new Rect(left, bottom, right - left, top - bottom);
+  }
+
+#if ANDROID_DEVICE
+  private const string cardboardClass =
+    "com.google.vrtoolkit.cardboard.plugins.unity.UnityCardboardActivity";
+  private AndroidJavaObject cardboardActivity;
+
+  private bool CallActivityMethod(string name, params object[] args) {
+    try {
+      cardboardActivity.Call(name, args);
+      return true;
+    } catch (AndroidJavaException e) {
+      Debug.LogError("Exception calling activity method " + name + ": " + e);
+      return false;
+    }
+
+  }
+
+  private bool CallActivityMethod<T>(ref T result, string name, params object[] args) {
+    try {
+      result = cardboardActivity.Call<T>(name, args);
+      return true;
+    } catch (AndroidJavaException e) {
+      Debug.LogError("Exception calling activity method " + name + ": " + e);
+      return false;
+    }
+  }
+
+  private void ConnectToActivity() {
+    try {
+      using (AndroidJavaClass player = new AndroidJavaClass(cardboardClass)) {
+        cardboardActivity = player.CallStatic<AndroidJavaObject>("getActivity");
+      }
+      config.canAccessActivity = true;
+    } catch (AndroidJavaException e) {
+      Debug.LogError("Cannot access UnityCardboardActivity. "
+        + "Verify that the jar is in Assets/Plugins/Android. " + e);
+    }
+    CallActivityMethod("initFromUnity", gameObject.name);
+  }
+
+  private void UpdateScreenDataFromActivity() {
+    CardboardProfile.Device device = new CardboardProfile.Device();
+    CardboardProfile.Screen screen = new CardboardProfile.Screen();
+
+    float[] lensData = null;
+    if (CallActivityMethod(ref lensData, "getLensParameters")) {
+      device.lenses.separation = lensData[0];
+      device.lenses.height = lensData[1];
+      device.lenses.screenDistance = lensData[2];
+    }
+
+    float[] screenSize = null;
+    if (CallActivityMethod(ref screenSize, "getScreenSizeMeters")) {
+      screen.width = screenSize[0];
+      screen.height = screenSize[1];
+      screen.border = screenSize[2];
+    }
+
+    float[] distCoeff = null;
+    if (CallActivityMethod(ref distCoeff, "getDistortionCoefficients")) {
+      device.distortion.k1 = distCoeff[0];
+      device.distortion.k2 = distCoeff[1];
+    }
+
+    float[] invDistCoeff = null;
+    if (CallActivityMethod(ref invDistCoeff, "getInverseDistortionCoefficients")) {
+      device.inverse.k1 = invDistCoeff[0];
+      device.inverse.k2 = invDistCoeff[1];
+
+    }
+
+    float[] maxFov = null;
+    if (CallActivityMethod(ref maxFov, "getLeftEyeMaximumFOV")) {
+      device.maxFOV.outer = maxFov[0];
+      device.maxFOV.upper = maxFov[1];
+      device.maxFOV.inner = maxFov[2];
+      device.maxFOV.lower = maxFov[3];
+    }
+
+    Profile = new CardboardProfile { screen=screen, device=device };
+  }
+
+  // Right-handed to left-handed matrix converter.
+  private static readonly Matrix4x4 flipZ = Matrix4x4.Scale(new Vector3(1, 1, -1));
+
+  public void UpdateFrameParamsFromActivity() {
+    float[] frameInfo = null;
+    // Pass nominal clip distances - will correct later for each camera.
+    if (!CallActivityMethod(ref frameInfo, "getFrameParams", 1.0f /* near */, 1000.0f /* far */)) {
+      return;
+    }
+
+    // Extract the matrices (currently that's all we get back).
+    int j = 0;
+    for (int i = 0; i < 16; ++i, ++j) {
+      headView[i] = frameInfo[j];
+    }
+    for (int i = 0; i < 16; ++i, ++j) {
+      leftEyeView[i] = frameInfo[j];
+    }
+    for (int i = 0; i < 16; ++i, ++j) {
+      leftEyeProj[i] = frameInfo[j];
+    }
+    for (int i = 0; i < 16; ++i, ++j) {
+      rightEyeView[i] = frameInfo[j];
+    }
+    for (int i = 0; i < 16; ++i, ++j) {
+      rightEyeProj[i] = frameInfo[j];
+    }
+    for (int i = 0; i < 16; ++i, ++j) {
+      leftEyeUndistortedProj[i] = frameInfo[j];
+    }
+    for (int i = 0; i < 16; ++i, ++j) {
+      rightEyeUndistortedProj[i] = frameInfo[j];
+    }
+
+    leftEyeRect = new Rect(frameInfo[j], frameInfo[j+1], frameInfo[j+2], frameInfo[j+3]);
+    j += 4;
+    rightEyeRect = new Rect(frameInfo[j], frameInfo[j+1], frameInfo[j+2], frameInfo[j+3]);
+
+    // Convert views to left-handed coordinates because Unity uses them
+    // for Transforms, which is what we will update from the views.
+    // Also invert because the incoming matrices go from camera space to
+    // cardboard space, and we want the opposite.
+    // Lastly, cancel out the head rotation from the eye views,
+    // because we are applying that on a parent object.
+    leftEyeView = flipZ * headView * leftEyeView.inverse * flipZ;
+    rightEyeView = flipZ * headView * rightEyeView.inverse * flipZ;
+    headView = flipZ * headView.inverse * flipZ;
+  }
+
+  // How long to hold a simulated screen tap.
+  private const float TAP_INJECTION_TIME = 0.1f;
+
+  private const long NO_DOWNTIME = -1;  // Sentinel for when down time is not set.
+
+  private long downTime = NO_DOWNTIME;  // Time the current tap injection started, if any.
+
+  // Fakes a screen tap by injecting a pointer-down and pointer-up events
+  // with a suitable delay between them.
+  IEnumerator DoAndroidScreenTap(int x, int y) {
+    if (downTime != NO_DOWNTIME) {  // Sanity check.
+      yield break;
+    }
+    if (!CallActivityMethod(ref downTime, "injectTouchDown", x, y)) {
+      yield break;
+    }
+    yield return new WaitForSeconds(TAP_INJECTION_TIME);
+    CallActivityMethod("injectTouchUp", x, y, downTime);
+    downTime = NO_DOWNTIME;
+  }
+
+#else
+
+  private static Matrix4x4 MakeProjection(float l, float t, float r, float b, float n, float f) {
+    Matrix4x4 m = Matrix4x4.zero;
+    m[0, 0] = 2 * n / (r - l);
+    m[1, 1] = 2 * n / (t - b);
+    m[0, 2] = (r + l) / (r - l);
+    m[1, 2] = (t + b) / (t - b);
+    m[2, 2] = (n + f) / (n - f);
+    m[2, 3] = 2 * n * f / (n - f);
+    m[3, 2] = -1;
+    return m;
+  }
+
+  private void UpdateSimulatedFrameParams() {
+    // Mock implementation for use in the Unity editor.
+    headView = Matrix4x4.identity;
+#if UNITY_EDITOR
+    SimulateHeadTracking();
+#endif
+
+    // Compute left eye matrices from screen and device params
+
+    leftEyeView = Matrix4x4.identity;
+    leftEyeView[0, 3] = -Profile.device.lenses.separation / 2;
+
+    float[] rect = GetLeftEyeVisibleTanAngles();
+    leftEyeProj = MakeProjection(rect[0], rect[1], rect[2], rect[3], 1, 1000);
+
+    rect = GetLeftEyeNoLensTanAngles();
+    leftEyeUndistortedProj = MakeProjection(rect[0], rect[1], rect[2], rect[3], 1, 1000);
+
+    leftEyeRect = GetLeftEyeVisibleScreenRect(rect);
+
+    // Right eye matrices same as left ones but for some sign flippage.
+
+    rightEyeView = leftEyeView;
+    rightEyeView[0, 3] *= -1;
+
+    rightEyeProj = leftEyeProj;
+    rightEyeProj[0, 2] *= -1;
+
+    rightEyeUndistortedProj = leftEyeUndistortedProj;
+    rightEyeUndistortedProj[0, 2] *= -1;
+
+    rightEyeRect = leftEyeRect;
+    rightEyeRect.x = 1 - rightEyeRect.xMax;
+  }
+#endif
+
+#if UNITY_EDITOR
+  [Tooltip("When playing in the editor, just release Ctrl to untilt the head.")]
+  public bool autoUntiltHead = true;
+
+  // Use mouse to emulate head in the editor.
+  private float mouseX = 0;
+  private float mouseY = 0;
+  private float mouseZ = 0;
+
+  private void SimulateHeadTracking() {
+    bool rolled = false;
+    if (Input.GetKey(KeyCode.LeftAlt) || Input.GetKey(KeyCode.RightAlt)) {
+      mouseX += Input.GetAxis("Mouse X") * 5;
+      if (mouseX <= -180) {
+        mouseX += 360;
+      } else if (mouseX > 180)
+        mouseX -= 360;
+      mouseY -= Input.GetAxis("Mouse Y") * 2.4f;
+      mouseY = Mathf.Clamp(mouseY, -80, 80);
+    } else if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl)) {
+      rolled = true;
+      mouseZ += Input.GetAxis("Mouse X") * 5;
+      mouseZ = Mathf.Clamp(mouseZ, -80, 80);
+    }
+    if (!rolled && autoUntiltHead) {
+      // People don't usually leave their heads tilted to one side for long.
+      mouseZ = Mathf.Lerp(mouseZ, 0, Time.deltaTime / (Time.deltaTime + 0.1f));
+    }
+    var rot = Quaternion.Euler(mouseY, mouseX, mouseZ);
+    headView = Matrix4x4.TRS(Vector3.zero, rot, Vector3.one);
+  }
+
+  private const float TOUCH_TIME_LIMIT = 0.2f;
+  private float touchStartTime = 0;
+
+  private void SimulateTrigger() {
+    if (!InCardboard) {
+      return;  // Only simulate trigger pull if there is a trigger to pull.
+    }
+
+    if (Input.GetMouseButtonDown(0)) {
+      touchStartTime = Time.time;
+    } else if (Input.GetMouseButtonUp(0)) {
+      if (Time.time - touchStartTime <= TOUCH_TIME_LIMIT) {
+        newCardboardTriggered = true;
+      }
+      touchStartTime = 0;
+    }
+  }
+#else
+  private GUIStyle style;
+
+  // The amount of time (in seconds) to show error message on GUI.
+  private const float GUI_ERROR_MSG_DURATION = 10;
+
+  private const string warning =
+@"Distortion correction is disabled.
+Requires Unity Android Pro v4.5+.
+See log for details.";
+
+  void OnGUI() {
+      if (Debug.isDebugBuild && !config.canApplyDistortionCorrection() &&
+              Time.realtimeSinceStartup <= GUI_ERROR_MSG_DURATION) {
+          DisplayDistortionCorrectionDisabledWarning();
+      }
+  }
+
+  private void DisplayDistortionCorrectionDisabledWarning() {
+      if (style == null) {
+          style = new GUIStyle();
+          style.normal.textColor = Color.red;
+          style.alignment = TextAnchor.LowerCenter;
+      }
+      if (VRModeEnabled) {
+          style.fontSize = (int)(50 * Screen.width / 1920f / 2);
+          GUI.Label(new Rect(0, 0, Screen.width / 2, Screen.height), warning, style);
+          GUI.Label(new Rect(Screen.width / 2, 0, Screen.width / 2, Screen.height), warning, style);
+      } else {
+          style.fontSize = (int)(50 * Screen.width / 1920f);
+          GUI.Label(new Rect(0, 0, Screen.width, Screen.height), warning, style);
+      }
+  }
+#endif
+}

--- a/Cardboard/Scripts/Cardboard.cs
+++ b/Cardboard/Scripts/Cardboard.cs
@@ -810,11 +810,11 @@ See log for details.";
       }
       if (VRModeEnabled) {
           style.fontSize = (int)(50 * Screen.width / 1920f / 2);
-          GUI.Label(new Rect(0, 0, Screen.width / 2, Screen.height), warning, style);
-          GUI.Label(new Rect(Screen.width / 2, 0, Screen.width / 2, Screen.height), warning, style);
+		  UnityEngine.GUILabel(new Rect(0, 0, Screen.width / 2, Screen.height), warning, style);
+		  UnityEngine.GUI.Label(new Rect(Screen.width / 2, 0, Screen.width / 2, Screen.height), warning, style);
       } else {
           style.fontSize = (int)(50 * Screen.width / 1920f);
-          GUI.Label(new Rect(0, 0, Screen.width, Screen.height), warning, style);
+		  UnityEngine.GUI.Label(new Rect(0, 0, Screen.width, Screen.height), warning, style);
       }
   }
 #endif

--- a/Cardboard/Scripts/Cardboard.cs.meta
+++ b/Cardboard/Scripts/Cardboard.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: a40b544b8c3553c40852ae7ad35a9343
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Scripts/CardboardEye.cs
+++ b/Cardboard/Scripts/CardboardEye.cs
@@ -1,0 +1,274 @@
+﻿// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using UnityEngine;
+using System.Reflection;
+
+// Controls one camera of a stereo pair.  Each frame, it mirrors the settings of
+// the parent mono Camera, and then sets up side-by-side stereo with an appropriate
+// projection based on the head-tracking data from the Cardboard.SDK object.
+// To enable a stereo camera pair, enable the parent mono camera and set
+// Cardboard.SDK.VRModeEnabled = true.
+[RequireComponent(typeof(Camera))]
+public class CardboardEye : MonoBehaviour {
+  // Whether this is the left eye or the right eye.
+  public Cardboard.Eye eye;
+
+  [Tooltip("Culling mask layers that this eye should toggle relative to the parent camera.")]
+  public LayerMask toggleCullingMask = 0;
+
+  // The stereo controller in charge of this eye (and whose mono camera
+  // we will copy settings from).
+  private StereoController controller;
+  public StereoController Controller {
+    // This property is set up to work both in editor and in player.
+    get {
+      if (transform.parent == null) { // Should not happen.
+        return null;
+      }
+      if ((Application.isEditor && !Application.isPlaying)
+          || controller == null) {
+        // Go find our controller.
+        return transform.parent.GetComponentInParent<StereoController>();
+      }
+      return controller;
+    }
+  }
+
+  public CardboardHead Head {
+    get {
+      return GetComponentInParent<CardboardHead>();
+    }
+  }
+
+  void Start() {
+    var ctlr = Controller;
+    if (ctlr == null) {
+      Debug.LogError("CardboardEye must be child of a StereoController.");
+      enabled = false;
+    }
+    // Save reference to the found controller.
+    controller = ctlr;
+  }
+
+  private void FixProjection(ref Matrix4x4 proj, float near, float far, float ipdScale) {
+    // Adjust for non-fullscreen camera.  Cardboard SDK assumes fullscreen,
+    // so the aspect ratio might not match.
+    float aspectFix = GetComponent<Camera>().rect.height / GetComponent<Camera>().rect.width / 2;
+    proj[0, 0] *= aspectFix;
+
+    // Adjust for IPD scale.  This changes the vergence of the two frustums.
+    Vector2 dir = transform.localPosition; // ignore Z
+    dir = dir.normalized * ipdScale;
+    proj[0, 2] *= Mathf.Abs(dir.x);
+    proj[1, 2] *= Mathf.Abs(dir.y);
+
+    // Cardboard had to pass "nominal" values of near/far to the SDK, which
+    // we fix here to match our mono camera's specific values.
+    proj[2, 2] = (near + far) / (near - far);
+    proj[2, 3] = 2 * near * far / (near - far);
+  }
+
+  public void Render() {
+    // Shouldn't happen because of the check in Start(), but just in case...
+    if (controller == null) {
+      return;
+    }
+
+    var camera = GetComponent<Camera>();
+    var monoCamera = controller.GetComponent<Camera>();
+    Matrix4x4 proj = Cardboard.SDK.Projection(eye);
+
+    CopyCameraAndMakeSideBySide(controller, proj[0,2], proj[1,2]);
+
+    // Zoom the stereo cameras if requested.
+    float lerp = Mathf.Clamp01(controller.matchByZoom) * Mathf.Clamp01(controller.matchMonoFOV);
+    // Lerping the reciprocal of proj(1,1) so zooming is linear in the frustum width, not the depth.
+    float monoProj11 = monoCamera.projectionMatrix[1, 1];
+    float zoom = 1 / Mathf.Lerp(1 / proj[1, 1], 1 / monoProj11, lerp) / proj[1, 1];
+    proj[0, 0] *= zoom;
+    proj[1, 1] *= zoom;
+
+    // Calculate stereo adjustments based on the center of interest.
+    float ipdScale;
+    float eyeOffset;
+    controller.ComputeStereoAdjustment(proj[1, 1], transform.lossyScale.z,
+                                       out ipdScale, out eyeOffset);
+
+    // Set up the eye's view transform.
+    transform.localPosition = ipdScale * Cardboard.SDK.EyeOffset(eye) +
+                              eyeOffset * Vector3.forward;
+
+    // Set up the eye's projection.
+    float near = monoCamera.nearClipPlane;
+    float far = monoCamera.farClipPlane;
+    FixProjection(ref proj, near, far, ipdScale);
+    camera.projectionMatrix = proj;
+
+    if (Application.isEditor) {
+      // So you can see the approximate frustum in the Scene view when the camera is selected.
+      camera.fieldOfView = 2 * Mathf.Atan(1 / proj[1, 1]) * Mathf.Rad2Deg;
+    }
+
+    if (!Cardboard.SDK.nativeDistortionCorrection) {
+      Matrix4x4 realProj = Cardboard.SDK.UndistortedProjection(eye);
+      FixProjection(ref realProj, near, far, ipdScale);
+      // Parts of the projection matrices that we need to convert texture coordinates between
+      // distorted and undistorted frustums.  Include the transform between texture space [0..1]
+      // and NDC [-1..1] (that's what the -1 and the /2 are for).  Also note that the zoom
+      // factor is removed, because that will interfere with the distortion calculation.
+      Vector4 projvec = new Vector4(proj[0, 0] / zoom, proj[1, 1] / zoom,
+                                    proj[0, 2] - 1, proj[1, 2] - 1) / 2;
+      Vector4 unprojvec = new Vector4(realProj[0, 0], realProj[1, 1],
+                                      realProj[0, 2] - 1, realProj[1, 2] - 1) / 2;
+      Shader.SetGlobalVector("_Projection", projvec);
+      Shader.SetGlobalVector("_Unprojection", unprojvec);
+      CardboardProfile p = Cardboard.SDK.Profile;
+      Shader.SetGlobalVector("_Undistortion",
+                             new Vector4(p.device.inverse.k1, p.device.inverse.k2));
+      Shader.SetGlobalVector("_Distortion",
+                             new Vector4(p.device.distortion.k1, p.device.distortion.k2));
+    }
+
+    RenderTexture stereoScreen = controller.StereoScreen;
+    int screenWidth = stereoScreen ? stereoScreen.width : Screen.width;
+    int screenHeight = stereoScreen ? stereoScreen.height : Screen.height;
+
+    if (stereoScreen == null) {
+      // We are rendering straight to the screen.  Use the reported rect that is visible
+      // through the device's lenses.
+      Rect view = Cardboard.SDK.EyeRect(eye);
+      Rect rect = camera.rect;
+      if (eye == Cardboard.Eye.Right) {
+        rect.x -= 0.5f;
+      }
+      rect.width *= 2 * view.width;
+      rect.x = view.x + 2 * rect.x * view.width;
+      rect.height *= view.height;
+      rect.y = view.y + rect.y * view.height;
+      if (Application.isEditor) {
+        // The Game window's aspect ratio may not match the fake device parameters.
+        float realAspect = (float)screenWidth / screenHeight;
+        float fakeAspect = Cardboard.SDK.Profile.screen.width / Cardboard.SDK.Profile.screen.height;
+        float aspectComparison = fakeAspect / realAspect;
+        if (aspectComparison < 1) {
+          rect.width *= aspectComparison;
+          rect.x *= aspectComparison;
+          rect.x += (1 - aspectComparison) / 2;
+        } else {
+          rect.height /= aspectComparison;
+        }
+      }
+      camera.rect = rect;
+    }
+
+    // Use the "fast" or "slow" method.  Fast means the camera draws right into one half of
+    // the stereo screen.  Slow means it draws first to a side buffer, and then the buffer
+    // is written to the screen. The slow method is provided because a lot of Image Effects
+    // don't work if you draw to only part of the window.
+    if (controller.directRender) {
+      // Redirect to our stereo screen.
+      camera.targetTexture = stereoScreen;
+      // Draw!
+      camera.Render();
+    } else {
+      // Save the viewport rectangle and reset to "full screen".
+      Rect pixRect = camera.pixelRect;
+      camera.rect = new Rect (0, 0, 1, 1);
+      // Redirect to a temporary texture.  The defaults are supposedly Android-friendly.
+      int depth = stereoScreen ? stereoScreen.depth : 16;
+      RenderTextureFormat format = stereoScreen ? stereoScreen.format : RenderTextureFormat.RGB565;
+      camera.targetTexture = RenderTexture.GetTemporary((int)pixRect.width, (int)pixRect.height,
+                                                        depth, format);
+      // Draw!
+      camera.Render();
+      // Blit the temp texture to the stereo screen.
+      RenderTexture oldTarget = RenderTexture.active;
+      RenderTexture.active = stereoScreen;
+      GL.PushMatrix();
+      GL.LoadPixelMatrix(0, screenWidth, screenHeight, 0);
+      // Camera rects are in screen coordinates (bottom left is origin), but DrawTexture takes a
+      // rect in GUI coordinates (top left is origin).
+      Rect blitRect = pixRect;
+      blitRect.y = screenHeight - pixRect.height - pixRect.y;
+      // Blit!
+      Graphics.DrawTexture(blitRect, camera.targetTexture);
+      // Clean up.
+      GL.PopMatrix();
+      RenderTexture.active = oldTarget;
+      RenderTexture.ReleaseTemporary(camera.targetTexture);
+    }
+    camera.targetTexture = null;
+  }
+
+  // Helper to copy camera settings from the controller's mono camera.
+  // Used in OnPreCull and the custom editor for StereoController.
+  // The parameters parx and pary, if not left at default, should come from a
+  // projection matrix returned by the SDK.
+  // They affect the apparent depth of the camera's window.  See OnPreCull().
+  public void CopyCameraAndMakeSideBySide(StereoController controller,
+                                          float parx = 0, float pary = 0) {
+    var camera = GetComponent<Camera>();
+
+    // Sync the camera properties.
+    camera.CopyFrom(controller.GetComponent<Camera>());
+    camera.cullingMask ^= toggleCullingMask.value;
+
+    // Reset transform, which was clobbered by the CopyFrom() call.
+    // Since we are a child of the mono camera, we inherit its
+    // transform already.
+    // Use nominal IPD for the editor.  During play, OnPreCull() will
+    // compute a real value.
+    float ipd = CardboardProfile.Default.device.lenses.separation * controller.stereoMultiplier;
+    transform.localPosition = (eye == Cardboard.Eye.Left ? -ipd/2 : ipd/2) * Vector3.right;
+    transform.localRotation = Quaternion.identity;
+    transform.localScale = Vector3.one;
+
+    // Set up side-by-side stereo.
+    // Note: The code is written this way so that non-fullscreen cameras
+    // (PIP: picture-in-picture) still work in stereo.  Even if the PIP's content is
+    // not going to be in stereo, the PIP itself still has to be rendered in both eyes.
+    Rect rect = camera.rect;
+
+    // Move away from edges if padding requested.  Some HMDs make the edges of the
+    // screen a bit hard to see.
+    Vector2 center = rect.center;
+    center.x = Mathf.Lerp(center.x, 0.5f, Mathf.Clamp01(controller.stereoPaddingX));
+    center.y = Mathf.Lerp(center.y, 0.5f, Mathf.Clamp01(controller.stereoPaddingY));
+    rect.center = center;
+
+    // Semi-hacky aspect ratio adjustment because the screen is only half as wide due
+    // to side-by-side stereo, to make sure the PIP width fits.
+    float width = Mathf.SmoothStep(-0.5f, 0.5f, (rect.width + 1) / 2);
+    rect.x += (rect.width - width) / 2;
+    rect.width = width;
+
+    // Divide the outside region of window proportionally in each half of the screen.
+    rect.x *= (0.5f - rect.width) / (1 - rect.width);
+    if (eye == Cardboard.Eye.Right) {
+      rect.x += 0.5f; // Move to right half of the screen.
+    }
+
+    // Adjust the window for requested parallax.  This affects the apparent depth of the
+    // window in the main camera's screen.  Useful for PIP windows only, where rect.width < 1.
+    float parallax = Mathf.Clamp01(controller.screenParallax);
+    if (controller.GetComponent<Camera>().rect.width < 1 && parallax > 0) {
+      // Note: parx and pary are signed, with opposite signs in each eye.
+      rect.x -= parx / 4 * parallax; // Extra factor of 1/2 because of side-by-side stereo.
+      rect.y -= pary / 2 * parallax;
+    }
+
+    camera.rect = rect;
+  }
+}

--- a/Cardboard/Scripts/CardboardEye.cs.meta
+++ b/Cardboard/Scripts/CardboardEye.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 5c9cfdc6c389e2742aa40f991195d828
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Scripts/CardboardGUI.cs
+++ b/Cardboard/Scripts/CardboardGUI.cs
@@ -1,0 +1,141 @@
+﻿// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using UnityEngine;
+
+// A utility class for redirecting OnGUI()-based UI elements onto a texture,
+// which can be drawn on a surface in the scene and thus appear in stereo.
+// The auxiliary CardboardGUIWindow class handles displaying the texture
+// in the scene.  CardboardGUI captures the OnGUI() calls, which need to be
+// modified slightly for this to work, and handles feeding back fake mouse
+// events into the Unity player based on the user's head and trigger actions.
+//
+// If the option is available, it is probably better to use a real 3D
+// GUI such as the new Unity4.6+ system.  But if you just want to get
+// existing projects based on OnGUI() to work in Cardboard, this class
+// can help.
+public class CardboardGUI : MonoBehaviour {
+
+  // The type of an OnGUI() method.
+  public delegate void OnGUICallback();
+
+  // Add a gameobject's OnGUI() to this event, which is called during the
+  // redirection phase to capture the UI in a texture.
+  public static event OnGUICallback onGUICallback;
+
+  // Unity is going to call OnGUI() methods as usual, in addition to them
+  // being called by the onGUICallback event.  To prevent this double
+  // call from affecting game logic, modify the OnGUI() method.  At the
+  // very top, add "if (!CardboardGUI.OKToDraw(this)) return; ".
+  // This will ensure only one OnGUI() call sequence occurs per frame,
+  // whether in VR Mode or not.
+  private static bool okToDraw;
+  public static bool OKToDraw(MonoBehaviour mb) {
+    return okToDraw && (mb == null || mb.enabled && mb.gameObject.activeInHierarchy);
+  }
+
+  // Unlike on a plain 2D screen, in Cardboard the edges of the screen are
+  // very hard to see.  UI elements will likely have to be moved towards
+  // the center for the user to be able to interact with them.  As this would
+  // obscure the view of the rest of the scene, the class provides this flag to
+  // hide or show the entire in-scene rendering of the GUI, so it can be shown
+  // only when the user needs it.
+  private static bool isGUIVisible;
+  public static bool IsGUIVisible {
+    get {
+      return isGUIVisible && Cardboard.SDK.VRModeEnabled && SystemInfo.supportsRenderTextures;
+    }
+    set {
+      isGUIVisible = value;
+    }
+  }
+
+  // A wrapper around the trigger event that lets the GUI, when it
+  // is visible, steal the trigger for mouse clicking.  Call this
+  // instead of Cardboard.SDK.CardboardTriggered when this behavior
+  // is desired.
+  public static bool CardboardTriggered {
+    get {
+      return !IsGUIVisible && Cardboard.SDK.CardboardTriggered;
+    }
+  }
+
+  [Tooltip("The color and transparency of the overall GUI screen.")]
+  public Color background = Color.clear;
+
+  // Texture that captures the OnGUI rendering.
+  private RenderTexture guiScreen;
+
+  void Awake() {
+    if (!SystemInfo.supportsRenderTextures) {
+      Debug.LogWarning("CardboardGUI disabled.  RenderTextures are not supported, either due to license or platform.");
+      enabled = false;
+    }
+  }
+
+  void Start() {
+    Create();
+  }
+
+  // Sets up the render texture and all the windows that will show parts of it.
+  public void Create() {
+    if (guiScreen != null) {
+      guiScreen.Release();
+    }
+    RenderTexture stereoScreen = Cardboard.SDK.StereoScreen;
+    int width = stereoScreen ? stereoScreen.width : Screen.width;
+    int height = stereoScreen ? stereoScreen.height : Screen.height;
+    guiScreen = new RenderTexture(width, height, 0, RenderTextureFormat.ARGB32);
+    guiScreen.Create();
+    foreach (var guiWindow in GetComponentsInChildren<CardboardGUIWindow>(true)) {
+      guiWindow.Create(guiScreen);
+    }
+  }
+
+  void LateUpdate() {
+    // When not in VR Mode, let normal OnGUI() calls proceed.
+    okToDraw = !Cardboard.SDK.VRModeEnabled;
+  }
+
+  void OnGUI() {
+    if (!IsGUIVisible) {
+      return;  // Nothing to do.
+    }
+    // OnGUI() is called multiple times per frame: once with event type "Layout",
+    // then once for each user input (key, mouse, touch, etc) that occurred in this
+    // frame, then finally once with event type "Repaint", during which the actual
+    // GUI drawing is done.  This last phase is the one we have to capture.
+    RenderTexture prevRT = null;
+    if (Event.current.type == EventType.Repaint) {
+      // Redirect rendering to our texture.
+      prevRT = RenderTexture.active;
+      RenderTexture.active = guiScreen;
+      GL.Clear(false, true, background);
+    }
+    if (onGUICallback != null) {
+      // Call all the OnGUI methods that have registered.
+      okToDraw = true;
+      onGUICallback();
+      okToDraw = false;
+    }
+    if (Event.current.type == EventType.Repaint) {
+      CardboardGUIMouse cgm = GetComponent<CardboardGUIMouse>();
+      if (cgm != null) {
+        cgm.DrawPointerImage();
+      }
+      // Clean up.
+      RenderTexture.active = prevRT;
+    }
+  }
+}

--- a/Cardboard/Scripts/CardboardGUI.cs.meta
+++ b/Cardboard/Scripts/CardboardGUI.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 46945e3ed78924bdea8171f8de038346
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Scripts/CardboardGUIMouse.cs
+++ b/Cardboard/Scripts/CardboardGUIMouse.cs
@@ -1,0 +1,104 @@
+﻿// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using UnityEngine;
+using System.Collections;
+
+public class CardboardGUIMouse : MonoBehaviour {
+
+  // If the app supports the use of some other pointing device, e.g. a gamepad
+  // or bluetooth mouse, then this field can be left null.  When set to a
+  // CardboardHead instance, then the user's head in effect becomes the mouse
+  // pointer and the Cardboard trigger becomes the mouse button.  The user
+  // looks at a GUI button and pulls the trigger to click it.
+  [Tooltip("The CardboardHead which drives the simulated mouse.")]
+  public CardboardHead head;
+
+  // The image to draw into the captured GUI texture representing the current
+  // mouse position.
+  [Tooltip("What to draw on the GUI surface for the simulated mouse pointer.")]
+  public Texture pointerImage;
+
+  [Tooltip("The size to draw the pointer in screen coordinates. " +
+           "Leave at 0,0 to use actual image size.")]
+  public Vector2 pointerSize;
+
+  [Tooltip("The screen pixel of the image to position over the mouse point.")]
+  public Vector2 pointerSpot;
+
+  // Whether to draw a pointer on the GUI surface, so the user can see
+  // where they are about to click.
+  private bool pointerVisible;
+
+  void LateUpdate() {
+    if (head == null) {  // Pointer not being controlled by user's head, so we bail.
+      pointerVisible = true;  // Draw pointer wherever Unity thinks the mouse is.
+      return;
+    }
+    if (!CardboardGUI.IsGUIVisible) {
+      pointerVisible = false;  // No GUI == no pointer to worry about.
+      return;
+    }
+    // Find which CardboardGUIWindow the user's gaze intersects first, if any.
+    Ray ray = head.Gaze;
+    CardboardGUIWindow hitWindow = null;
+    float minDist = Mathf.Infinity;
+    Vector2 pos = Vector2.zero;
+    foreach (var guiWindow in GetComponentsInChildren<CardboardGUIWindow>()) {
+      RaycastHit hit;
+      if (guiWindow.GetComponent<Collider>().Raycast(ray, out hit, Mathf.Infinity)
+          && hit.distance < minDist) {
+        minDist = hit.distance;
+        hitWindow = guiWindow;
+        pos = hit.textureCoord;
+      }
+    }
+    if (hitWindow == null) {
+      // Don't draw the pointer unless the user is looking at a pixel of the GUI screen.
+      pointerVisible = false;
+      return;
+    }
+    // Convert from the intersected window's texture coordinates to screen coordinates.
+    pos.x = hitWindow.rect.xMin + hitWindow.rect.width * pos.x;
+    pos.y = hitWindow.rect.yMin + hitWindow.rect.height * pos.y;
+    int x = (int)(pos.x * Screen.width);
+    // Unity GUI Y-coordinates ascend top-to-bottom, as do the quad's texture coordinates,
+    // while screen Y-coordinates ascend bottom-to-top.
+    int y = (int)((1 - pos.y) * Screen.height);
+    // Send the necessary event to Unity - next frame it will update the mouse.
+    if (Cardboard.SDK.CardboardTriggered) {
+      Cardboard.SDK.InjectMouseClick(x, y);
+    } else {
+      Cardboard.SDK.InjectMouseMove(x, y);
+    }
+    // OK to draw the pointer image.
+    pointerVisible = true;
+  }
+
+  // Draw the fake mouse pointer.  Called by CardboardGUI after the rest of the UI is done.
+  public void DrawPointerImage() {
+    if (pointerImage == null || !pointerVisible || !enabled) {
+      return;
+    }
+    Vector2 pos = (Vector2)Input.mousePosition;
+    Vector2 spot = pointerSpot;
+    Vector2 size = pointerSize;
+    if (size.sqrMagnitude < 1) {  // If pointerSize was left == 0, just use size of image.
+      size.x = pointerImage.width;
+      size.y = pointerImage.height;
+    }
+    GUI.DrawTexture(new Rect(pos.x - spot.x, Screen.height - pos.y - spot.y, size.x, size.y),
+                    pointerImage, ScaleMode.StretchToFill);
+  }
+}

--- a/Cardboard/Scripts/CardboardGUIMouse.cs
+++ b/Cardboard/Scripts/CardboardGUIMouse.cs
@@ -98,7 +98,7 @@ public class CardboardGUIMouse : MonoBehaviour {
       size.x = pointerImage.width;
       size.y = pointerImage.height;
     }
-    GUI.DrawTexture(new Rect(pos.x - spot.x, Screen.height - pos.y - spot.y, size.x, size.y),
+	UnityEngine.GUI.DrawTexture(new Rect(pos.x - spot.x, Screen.height - pos.y - spot.y, size.x, size.y),
                     pointerImage, ScaleMode.StretchToFill);
   }
 }

--- a/Cardboard/Scripts/CardboardGUIMouse.cs.meta
+++ b/Cardboard/Scripts/CardboardGUIMouse.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: f06724eec91fb4704a525c71a8e8deea
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Scripts/CardboardGUIWindow.cs
+++ b/Cardboard/Scripts/CardboardGUIWindow.cs
@@ -1,0 +1,79 @@
+﻿// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using UnityEngine;
+
+// Works with CardboardGUI to show all or part of the OnGUI-rendered
+// UI on a mesh in the scene.  There should be one or more of these
+// as children of the CardboardGUI gameobject.  Each one specifies
+// the region of the captured OnGUI screen to show on its own mesh.
+// This allows you to place pieces of the GUI in the scene at different
+// distances and angles to the user without having to change any of the
+// OnGUI methods themselves.
+//
+// The rendering code here takes care of shader and texture setup.  The
+// choice of mesh is yours, but a quad looks good.  The mesh is scaled to
+// match the aspect ratio of the screen region shown.  The attached
+// collider is used for ray instersection with the user's gaze, so it
+// should return texture coordinates that match those of the meshfilter.
+//
+// Individual portions of the GUI can be turned on or off by enabling
+// this component independently of the sibling gameobjects.
+[RequireComponent(typeof(MeshFilter))]
+[RequireComponent(typeof(MeshRenderer))]
+[RequireComponent(typeof(Collider))]
+public class CardboardGUIWindow : MonoBehaviour {
+  private MeshRenderer meshRenderer;
+
+  void Reset() {
+    rect = new Rect(0,0,1,1);  // Make window show the full GUI screen.
+  }
+
+  [Tooltip("The portion of the OnGUI screen to show in this window. " +
+           "Use the same units as for Camera viewports.")]
+  public Rect rect;
+
+  void Awake() {
+    meshRenderer = GetComponent<MeshRenderer>();
+    if (!SystemInfo.supportsRenderTextures) {
+      enabled = false;
+    }
+  }
+
+  // Make a material that points to the target texture.  Texture scale
+  // and offset will be controlled by rect.
+  public void Create(RenderTexture target) {
+    meshRenderer.material = new Material(Shader.Find("Cardboard/GUIScreen")) {
+      mainTexture = target,
+      mainTextureOffset = rect.position,
+      mainTextureScale = rect.size
+    };
+  }
+
+  // Turn off this window.
+  void OnDisable() {
+    meshRenderer.enabled = false;
+  }
+
+  void LateUpdate() {
+    // Only render window when the overall GUI is enabled.
+    meshRenderer.enabled = CardboardGUI.IsGUIVisible;
+    // Keep material and object scale in sync with rect.
+    meshRenderer.material.mainTextureOffset = rect.position;
+    meshRenderer.material.mainTextureScale = rect.size;
+    float aspect = (Screen.width * rect.width) /
+                   (Screen.height * rect.height);
+    transform.localScale = new Vector3(aspect, 1, 1);
+  }
+}

--- a/Cardboard/Scripts/CardboardGUIWindow.cs.meta
+++ b/Cardboard/Scripts/CardboardGUIWindow.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: b076d97177f8c446c97ffb15e968d1af
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Scripts/CardboardHead.cs
+++ b/Cardboard/Scripts/CardboardHead.cs
@@ -1,0 +1,68 @@
+﻿// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using UnityEngine;
+
+public class CardboardHead : MonoBehaviour {
+
+  // If set, the head transform will be relative to it.
+  public Transform target;
+
+  // Determine whether head updates early or late in frame.
+  // Defaults to false in order to reduce latency.
+  // Set this to true if you see jitter due to other scripts using this
+  // object's orientation (or a child's) in their own LateUpdate() functions,
+  // e.g. to cast rays.
+  public bool updateEarly = false;
+
+  // Where is this head looking?
+  public Ray Gaze {
+    get {
+      UpdateHead();
+      return new Ray(transform.position, transform.forward);
+    }
+  }
+
+  private bool updated;
+
+  void Update() {
+    updated = false;  // OK to recompute head pose.
+    if (updateEarly) {
+      UpdateHead();
+    }
+  }
+
+  // Normally, update head pose now.
+  void LateUpdate() {
+    UpdateHead();
+  }
+
+  // Compute new head pose.
+  private void UpdateHead() {
+    if (updated) {  // Only one update per frame, please.
+      return;
+    }
+    updated = true;
+    if (!Cardboard.SDK.UpdateState()) {
+      return;
+    }
+
+    var rot = Cardboard.SDK.HeadRotation;
+    if (target == null) {
+      transform.localRotation = rot;
+    } else {
+      transform.rotation = rot * target.rotation;
+    }
+  }
+}

--- a/Cardboard/Scripts/CardboardHead.cs.meta
+++ b/Cardboard/Scripts/CardboardHead.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: f1578549c7fcc4f6fa1b063992091672
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Scripts/CardboardProfile.cs
+++ b/Cardboard/Scripts/CardboardProfile.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using UnityEngine;
+
+// Measurements of a particular phone in a particular Cardboard device.
+public class CardboardProfile {
+  public CardboardProfile Clone() {
+    return new CardboardProfile {
+      screen = this.screen,
+      device = this.device
+    };
+  }
+
+  // Information about the screen.  All distances in meters, measured as the phone is expected
+  // to be placed in the Cardboard, i.e. landscape orientation.
+  public struct Screen {
+    public float width;
+    public float height;
+    public float border;  // Distance from bottom of the cardboard to the bottom edge of screen.
+  }
+
+  // Information about the lens placement in the Cardboard.  All distances in meters.
+  public struct Lenses {
+    public float separation;  // Center to center.
+    public float height;      // Height of lens center from bottom of cardboard.
+    public float screenDistance; // Distance from lens center to the phone screen.
+  }
+
+  // Information about the viewing angles through the lenses.  All angles in degrees, measured
+  // away from the optical axis, i.e. angles are all positive.  It is assumed that left and right
+  // eye FOVs are mirror images, so that both have the same inner and outer angles.  Angles do not
+  // need to account for the limits due to screen size.
+  public struct MaxFOV {
+    public float outer;  // Towards the side of the screen.
+    public float inner;  // Towards the center line of the screen.
+    public float upper;  // Towards the top of the screen.
+    public float lower;  // Towards the bottom of the screen.
+  }
+
+  // Information on how the lens distorts light rays.  Also used for the (approximate) inverse
+  // distortion.  Assumes a radially symmetric pincushion/barrel distortion model.
+  public struct Distortion {
+    public float k1;
+    public float k2;
+
+    public float distort(float r) {
+      float r2 = r * r;
+      return ((k2 * r2 + k1) * r2 + 1) * r;
+    }
+  }
+
+  public struct Device {
+    public Lenses lenses;
+    public MaxFOV maxFOV;
+    public Distortion distortion;
+    public Distortion inverse;
+  }
+
+  // The combined set of information about a Cardboard profile.
+  public Screen screen;
+  public Device device;
+
+  // Some known profiles.
+
+  public static readonly Screen Nexus5 = new Screen {
+    width = 0.110f,
+    height = 0.062f,
+    border = 0.003f
+  };
+
+  public static readonly Device Original = new Device {
+    lenses = {
+      separation = 0.060f,
+      height = 0.035f,
+      screenDistance = 0.042f
+    },
+    maxFOV = {
+      outer = 40.0f,
+      inner = 40.0f,
+      upper = 40.0f,
+      lower = 40.0f
+    },
+    distortion = {
+      k1 = 0.441f,
+      k2 = 0.156f
+    },
+    inverse = {
+      k1 = -0.423f,
+      k2 = 0.239f
+    }
+  };
+
+  // Nexus 5 in an original Cardboard.
+  public static readonly CardboardProfile Default = new CardboardProfile {
+    screen = Nexus5,
+    device = Original
+  };
+}

--- a/Cardboard/Scripts/CardboardProfile.cs.meta
+++ b/Cardboard/Scripts/CardboardProfile.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 2cc48090f46d244bba130fef5ad58876
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Scripts/RadialUndistortionEffect.cs
+++ b/Cardboard/Scripts/RadialUndistortionEffect.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using UnityEngine;
+using System.Collections;
+
+// Applies the inverse of the lens distortion to the image.  The image is "undistorted" so
+// that when viewed through the lenses (which redistort), the image looks normal.  In the case
+// of Cardboard, the lenses apply a pincushion distortion, so this effect applies a barrel
+// distortion to counteract that.
+[RequireComponent(typeof(Camera))]
+public class RadialUndistortionEffect : MonoBehaviour {
+
+  private Material material;
+
+  void Awake() {
+    if (!SystemInfo.supportsRenderTextures) {
+      Debug.Log("Radial Undistortion disabled: render textures not supported.");
+      return;
+    }
+    Shader shader = Shader.Find("Cardboard/Radial Undistortion");
+    if (shader == null) {
+      Debug.Log("Radial Undistortion disabled: shader not found.");
+      return;
+    }
+    material = new Material(shader);
+  }
+
+  void OnRenderImage(RenderTexture source, RenderTexture dest) {
+    // Check if we found our shader, and that native distortion correction is OFF.
+    if (material == null || Cardboard.SDK.nativeDistortionCorrection) {
+      // Pass through, no effect.
+      Graphics.Blit(source, dest);
+    } else {
+      // Undistort the image.
+      Graphics.Blit(source, dest, material);
+    }
+  }
+}

--- a/Cardboard/Scripts/RadialUndistortionEffect.cs.meta
+++ b/Cardboard/Scripts/RadialUndistortionEffect.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 5888e93dcbacc470d9a54e48cddb00d2
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Scripts/SkyboxMesh.cs
+++ b/Cardboard/Scripts/SkyboxMesh.cs
@@ -1,0 +1,200 @@
+// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Original code by Nora
+// http://stereoarts.jp
+//
+// Retrieved from:
+// https://developer.oculusvr.com/forums/viewtopic.php?f=37&t=844#p28982
+//
+// Modified by Google:
+//   Combined the 6 separate meshes into a single mesh with submeshes.
+//
+// Usage:
+//   Attach to a camera object, and it meshifies the camera's skybox at runtime.
+//   The skybox is automatically scaled to fit just inside the far clipping
+//   plane and is kept centered on the camera.
+
+using UnityEngine;
+
+[RequireComponent(typeof(Camera))]
+public class SkyboxMesh : MonoBehaviour {
+  public enum Shape {
+    Sphere,
+    Cube,
+  }
+
+  public Shape shape = Shape.Sphere;
+  public int segments = 32;
+  public int layer = 0;
+
+  private GameObject skybox;
+
+  void Awake() {
+    var sky = GetComponent<Skybox>();
+    Material skymat = sky != null ? sky.material : RenderSettings.skybox;
+    if (skymat == null) {
+      enabled = false;
+      return;
+    }
+
+    skybox = new GameObject(skymat.name + "SkyMesh");
+    skybox.transform.parent = transform;
+    skybox.transform.localPosition = Vector3.zero;
+    skybox.layer = layer;
+
+    var filter = skybox.AddComponent<MeshFilter>();
+    filter.mesh = _CreateSkyboxMesh();
+
+    Material mat = new Material(Shader.Find("Cardboard/SkyboxMesh"));
+    var render = skybox.AddComponent<MeshRenderer>();
+    render.sharedMaterials = new Material[] {
+        new Material(mat) { mainTexture = skymat.GetTexture("_FrontTex") },
+        new Material(mat) { mainTexture = skymat.GetTexture("_LeftTex")  },
+        new Material(mat) { mainTexture = skymat.GetTexture("_BackTex")  },
+        new Material(mat) { mainTexture = skymat.GetTexture("_RightTex") },
+        new Material(mat) { mainTexture = skymat.GetTexture("_UpTex")    },
+        new Material(mat) { mainTexture = skymat.GetTexture("_DownTex")  }};
+    render.castShadows = false;
+    render.receiveShadows = false;
+  }
+
+  void LateUpdate() {
+    var camera = GetComponent<Camera>();
+    // Only visible if the owning camera needs it.
+    skybox.GetComponent<Renderer>().enabled =
+      camera.enabled && (camera.clearFlags == CameraClearFlags.Skybox);
+    // Scale up to just fit inside the far clip plane.
+    Vector3 scale = transform.lossyScale;
+    float far = camera.farClipPlane * 0.95f;
+    if (shape == Shape.Cube) {
+      far /= Mathf.Sqrt(3);  // Corners need to fit inside the frustum.
+    }
+    scale.x = far / scale.x;
+    scale.y = far / scale.y;
+    scale.z = far / scale.z;
+    // Center on the camera.
+    skybox.transform.localPosition = Vector3.zero;
+    skybox.transform.localScale = scale;
+    // Keep orientation fixed in the world.
+    skybox.transform.rotation = Quaternion.identity;
+  }
+
+  Mesh _CreateMesh() {
+    Mesh mesh = new Mesh();
+
+    int hvCount2 = this.segments + 1;
+    int hvCount2Half = hvCount2 / 2;
+    int numVertices = hvCount2 * hvCount2;
+    int numTriangles = this.segments * this.segments * 6;
+    Vector3[] vertices = new Vector3[numVertices];
+    Vector2[] uvs = new Vector2[numVertices];
+    int[] triangles = new int[numTriangles];
+
+    float scaleFactor = 2.0f / (float)this.segments;
+    float uvFactor = 1.0f / (float)this.segments;
+
+    if (this.segments <= 1 || this.shape == Shape.Cube) {
+      float ty = 0.0f, py = -1.0f;
+      int index = 0;
+      for (int y = 0; y < hvCount2; ++y, ty += uvFactor, py += scaleFactor) {
+        float tx = 0.0f, px = -1.0f;
+        for (int x = 0; x < hvCount2; ++x, ++index, tx += uvFactor, px += scaleFactor) {
+          vertices[index] = new Vector3(px, py, 1.0f);
+          uvs[index] = new Vector2(tx, ty);
+        }
+      }
+    } else {
+      float ty = 0.0f, py = -1.0f;
+      int index = 0, indexY = 0;
+      for (int y = 0; y <= hvCount2Half;
+          ++y, indexY += hvCount2, ty += uvFactor, py += scaleFactor) {
+        float tx = 0.0f, px = -1.0f, py2 = py * py;
+        int x = 0;
+        for (; x <= hvCount2Half; ++x, ++index, tx += uvFactor, px += scaleFactor) {
+          float d = Mathf.Sqrt(px * px + py2 + 1.0f);
+          float theta = Mathf.Acos(1.0f / d);
+          float phi = Mathf.Atan2(py, px);
+          float sinTheta = Mathf.Sin(theta);
+          vertices[index] = new Vector3(
+              sinTheta * Mathf.Cos(phi),
+              sinTheta * Mathf.Sin(phi),
+              Mathf.Cos(theta));
+          uvs[index] = new Vector2(tx, ty);
+        }
+        int indexX = hvCount2Half - 1;
+        for (; x < hvCount2; ++x, ++index, --indexX, tx += uvFactor, px += scaleFactor) {
+          Vector3 v = vertices[indexY + indexX];
+          vertices[index] = new Vector3(-v.x, v.y, v.z);
+          uvs[index] = new Vector2(tx, ty);
+        }
+      }
+      indexY = (hvCount2Half - 1) * hvCount2;
+      for (int y = hvCount2Half + 1; y < hvCount2;
+          ++y, indexY -= hvCount2, ty += uvFactor, py += scaleFactor) {
+        float tx = 0.0f, px = -1.0f;
+        int x = 0;
+        for (; x <= hvCount2Half; ++x, ++index, tx += uvFactor, px += scaleFactor) {
+          Vector3 v = vertices[indexY + x];
+          vertices[index] = new Vector3(v.x, -v.y, v.z);
+          uvs[index] = new Vector2(tx, ty);
+        }
+        int indexX = hvCount2Half - 1;
+        for (; x < hvCount2; ++x, ++index, --indexX, tx += uvFactor, px += scaleFactor) {
+          Vector3 v = vertices[indexY + indexX];
+          vertices[index] = new Vector3(-v.x, -v.y, v.z);
+          uvs[index] = new Vector2(tx, ty);
+        }
+      }
+    }
+
+    for (int y = 0, index = 0, ofst = 0; y < this.segments; ++y, ofst += hvCount2) {
+      int y0 = ofst, y1 = ofst + hvCount2;
+      for (int x = 0; x < this.segments; ++x, index += 6) {
+        triangles[index + 0] = y0 + x;
+        triangles[index + 1] = y1 + x;
+        triangles[index + 2] = y0 + x + 1;
+        triangles[index + 3] = y1 + x;
+        triangles[index + 4] = y1 + x + 1;
+        triangles[index + 5] = y0 + x + 1;
+      }
+    }
+
+    mesh.vertices = vertices;
+    mesh.uv = uvs;
+    mesh.triangles = triangles;
+    return mesh;
+  }
+
+  CombineInstance _CreatePlane(Mesh mesh, Quaternion rotation) {
+    return new CombineInstance() {
+        mesh = mesh,
+        subMeshIndex = 0,
+        transform = Matrix4x4.TRS(Vector3.zero, rotation, Vector3.one)};
+  }
+
+  Mesh _CreateSkyboxMesh() {
+    Mesh mesh = _CreateMesh();
+    var comb = new CombineInstance[] {
+        _CreatePlane(mesh, Quaternion.identity),
+        _CreatePlane(mesh, Quaternion.Euler(0.0f, 90.0f, 0.0f)),
+        _CreatePlane(mesh, Quaternion.Euler(0.0f, 180.0f, 0.0f)),
+        _CreatePlane(mesh, Quaternion.Euler(0.0f, 270.0f, 0.0f)),
+        _CreatePlane(mesh, Quaternion.Euler(-90.0f, 0.0f, 0.0f)),
+        _CreatePlane(mesh, Quaternion.Euler(90.0f, 0.0f, 0.0f))};
+    Mesh skymesh = new Mesh();
+    skymesh.CombineMeshes(comb, false, true);
+    return skymesh;
+  }
+}

--- a/Cardboard/Scripts/SkyboxMesh.cs
+++ b/Cardboard/Scripts/SkyboxMesh.cs
@@ -66,7 +66,7 @@ public class SkyboxMesh : MonoBehaviour {
         new Material(mat) { mainTexture = skymat.GetTexture("_RightTex") },
         new Material(mat) { mainTexture = skymat.GetTexture("_UpTex")    },
         new Material(mat) { mainTexture = skymat.GetTexture("_DownTex")  }};
-    render.castShadows = false;
+    render.shadowCastingMode = "Off";
     render.receiveShadows = false;
   }
 

--- a/Cardboard/Scripts/SkyboxMesh.cs.meta
+++ b/Cardboard/Scripts/SkyboxMesh.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 1842d86d69a644a109b06ba5a5935819
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Scripts/StereoController.cs
+++ b/Cardboard/Scripts/StereoController.cs
@@ -1,0 +1,269 @@
+﻿// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using UnityEngine;
+using System.Collections;
+using System.Linq;
+
+// Controls a pair of CardboardEye objects that will render the stereo view
+// of the camera this script is attached to.
+[RequireComponent(typeof(Camera))]
+public class StereoController : MonoBehaviour {
+  [Tooltip("Whether to draw directly to the output window (true), or " +
+           "to an offscreen buffer first and then blit (false).  Image " +
+           " Effects and Deferred Lighting may only work if set to false.")]
+  public bool directRender = true;
+
+  // Adjusts the level of stereopsis for this stereo rig.  Note that this
+  // parameter is not the virtual size of the head -- use a scale on the head
+  // game object for that.  Instead, it is a control on eye vergence, or
+  // rather, how cross-eyed or not the stereo rig is.  Set to 0 to turn
+  // off stereo in this rig independently of any others.
+  [Tooltip("Set the stereo level for this camera.")]
+  [Range(0,1)]
+  public float stereoMultiplier = 1.0f;
+
+  // The stereo cameras by default use the actual optical FOV of the Cardboard device,
+  // because otherwise the match between head motion and scene motion is broken, which
+  // impacts the virtual reality effect.  However, in some cases it is desirable to
+  // adjust the FOV anyway, for special effects or artistic reasons.  But in no case
+  // should the FOV be allowed to remain very different from the true optical FOV for
+  // very long, or users will experience discomfort.
+  //
+  // This value determines how much to match the mono camera's field of view.  This is
+  // a fraction: 0 means no matching, 1 means full matching, and values in between are
+  // compromises.  Reasons for not matching 100% would include preserving some VR-ness,
+  // and that due to the lens distortion the edges of the view are not as easily seen as
+  // when the phone is not in VR-mode.
+  //
+  // Another use for this variable is to preserve scene composition against differences
+  // in the optical FOV of various Cardboard models.  In all cases, this value simply
+  // lets the mono camera have some control over the scene in VR mode, like it does in
+  // non-VR mode.
+  [Tooltip("How much to adjust the stereo field of view to match this camera.")]
+  [Range(0,1)]
+  public float matchMonoFOV = 0;
+
+  // Determines the method by which the stereo cameras' FOVs are matched to the mono
+  // camera's FOV (assuming matchMonoFOV is not 0).  The default is to move the stereo
+  // cameras (matchByZoom = 0), with the option to instead do a simple camera zoom
+  // (matchByZoom = 1).  In-between values yield a mix of the two behaviors.
+  //
+  // It is not recommended to use simple zooming for typical scene composition, as it
+  // conflicts with the VR need to match the user's head motion with the corresponding
+  // scene motion.  This should be reserved for special effects such as when the player
+  // views the scene through a telescope or other magnifier (and thus the player knows
+  // that VR is going to be affected), or similar situations.
+  //
+  // Note that matching by moving the eyes requires that the centerOfInterest object
+  // be non-null, or there will be no effect.
+  [Tooltip("Whether to adjust FOV by moving the eyes (0) or simply zooming (1).")]
+  [Range(0,1)]
+  public float matchByZoom = 0;
+
+  // Matching the mono camera's field of view in stereo by moving the eyes requires
+  // a designated "center of interest".  This is either a point in space (an empty
+  // gameobject) you place in the scene as a sort of "3D cursor", or an actual scene
+  // entity which the player is likely to be focussed on.
+  //
+  // The FOV adjustment is done by moving the eyes toward or away from the COI
+  // so that it appears to have the same size on screen as it would in the mono
+  // camera.  This is disabled if the COI is null.
+  [Tooltip("Object or point where field of view matching is done.")]
+  public Transform centerOfInterest;
+
+  // The COI is generally meant to be just a point in space, like a 3D cursor.
+  // Occasionally, you will want it to be an actual object with size.  Set this
+  // to the approximate radius of the object to help the FOV-matching code
+  // compensate for the object's horizon when it is close to the camera.
+  [Tooltip("If COI is an object, its approximate size.")]
+  public float radiusOfInterest = 0;
+
+  // If true, check that the centerOfInterest is between the min and max comfortable
+  // viewing distances (see Cardboard.cs), or else adjust the stereo multiplier to
+  // compensate.  If the COI has a radius, then the near side is checked.  COI must
+  // be non-null for this setting to have any effect.
+  [Tooltip("Adjust stereo level when COI gets too close or too far.")]
+  public bool checkStereoComfort = true;
+
+  // For picture-in-picture cameras that don't fill the entire screen,
+  // set the virtual depth of the window itself.  A value of 0 means
+  // zero parallax, which is fairly close.  A value of 1 means "full"
+  // parallax, which is equal to the interpupillary distance and equates
+  // to an infinitely distant window.  This does not affect the actual
+  // screen size of the the window (in pixels), only the stereo separation
+  // of the left and right images.
+  [Tooltip("Adjust the virtual depth of this camera's window (picture-in-picture only).")]
+  [Range(0,1)]
+  public float screenParallax = 0;
+
+  // For picture-in-picture cameras, move the window away from the edges
+  // in VR Mode to make it easier to see.  The optics of HMDs make the screen
+  // edges hard to see sometimes, so you can use this to keep the PIP visible
+  // whether in VR Mode or not.  The x value is the fraction of the screen along
+  // either side to pad, and the y value is for the top and bottom of the screen.
+  [Tooltip("Move the camera window horizontally towards the center of the screen (PIP only).")]
+  [Range(0,1)]
+  public float stereoPaddingX = 0;
+
+  [Tooltip("Move the camera window vertically towards the center of the screen (PIP only).")]
+  [Range(0,1)]
+  public float stereoPaddingY = 0;
+
+  // Flags whether we rendered in stereo for this frame.
+  private bool renderedStereo = false;
+
+  // Returns the CardboardEye components that we control.
+  public CardboardEye[] Eyes {
+    get {
+      return GetComponentsInChildren<CardboardEye>(true)
+             .Where(eye => eye.Controller == this)
+             .ToArray();
+    }
+  }
+
+  // Returns the nearest CardboardHead that affects our eyes.
+  public CardboardHead Head {
+    get {
+      return Eyes.Select(eye => eye.Head).FirstOrDefault();
+    }
+  }
+
+  // Where the stereo eyes will render the scene.
+  public RenderTexture StereoScreen {
+    get {
+      return GetComponent<Camera>().targetTexture ?? Cardboard.SDK.StereoScreen;
+    }
+  }
+
+  void Awake() {
+    AddStereoRig();
+  }
+
+  // Helper routine for creation of a stereo rig.  Used by the
+  // custom editor for this class, or to build the rig at runtime.
+  public void AddStereoRig() {
+    if (Eyes.Length > 0) {  // Simplistic test if rig already exists.
+      return;
+    }
+    CreateEye(Cardboard.Eye.Left);
+    CreateEye(Cardboard.Eye.Right);
+    if (Head == null) {
+      gameObject.AddComponent<CardboardHead>();
+    }
+    if (GetComponent<Camera>().tag == "MainCamera" && GetComponent<SkyboxMesh>() == null) {
+      gameObject.AddComponent<SkyboxMesh>();
+    }
+  }
+
+  // Helper routine for creation of a stereo eye.
+  private void CreateEye(Cardboard.Eye eye) {
+    string nm = name + (eye == Cardboard.Eye.Left ? " Left" : " Right");
+    GameObject go = new GameObject(nm);
+    go.transform.parent = transform;
+    go.AddComponent<Camera>().enabled = false;
+    if (GetComponent<GUILayer>() != null) {
+      go.AddComponent<GUILayer>();
+    }
+    if (GetComponent("FlareLayer") != null) {
+      go.AddComponent<FlareLayer>();
+    }
+    var cardboardEye = go.AddComponent<CardboardEye>();
+    cardboardEye.eye = eye;
+    cardboardEye.CopyCameraAndMakeSideBySide(this);
+  }
+
+  // Given information about a specific camera (usually one of the stereo eyes),
+  // computes an adjustment to the stereo settings for both FOV matching and
+  // stereo comfort.  The input is the [1,1] entry of the camera's projection
+  // matrix, representing the vertical field of view, and the overall scale
+  // being applied to the Z axis.  The output is a multiplier of the IPD to
+  // use for offseting the eyes laterally, and an offset in the eye's Z direction
+  // to account for the FOV difference.  The eye offset is in local coordinates.
+  public void ComputeStereoAdjustment(float proj11, float zScale,
+                                      out float ipdScale, out float eyeOffset) {
+    ipdScale = stereoMultiplier;
+    eyeOffset = 0;
+    if (centerOfInterest == null || !centerOfInterest.gameObject.activeInHierarchy) {
+      return;
+    }
+
+    // Distance of COI relative to head.
+    float distance = (centerOfInterest.position - transform.position).magnitude;
+
+    // Size of the COI, clamped to [0..distance] for mathematical sanity in following equations.
+    float radius = Mathf.Clamp(radiusOfInterest, 0, distance);
+
+    // Move the eye so that COI has about the same size onscreen as in the mono camera FOV.
+    // The radius affects the horizon location, which is where the screen-size matching has to
+    // occur.
+    float scale = proj11 / GetComponent<Camera>().projectionMatrix[1, 1];  // vertical FOV
+    float offset =
+        Mathf.Sqrt(radius * radius + (distance * distance - radius * radius) * scale * scale);
+    eyeOffset = (distance - offset) * Mathf.Clamp01(matchMonoFOV) / zScale;
+
+    // Manage IPD scale based on the distance to the COI.
+    if (checkStereoComfort) {
+      float minComfort = Cardboard.SDK.MinimumComfortDistance;
+      float maxComfort = Cardboard.SDK.MaximumComfortDistance;
+      if (minComfort < maxComfort) {  // Sanity check.
+        // If closer than the minimum comfort distance, IPD is scaled down.
+        // If farther than the maximum comfort distance, IPD is scaled up.
+        // The result is that parallax is clamped within a reasonable range.
+        float minDistance = (distance - radius) / zScale - eyeOffset;
+        ipdScale *= minDistance / Mathf.Clamp(minDistance, minComfort, maxComfort);
+      }
+    }
+  }
+
+  void Start() {
+    StartCoroutine("EndOfFrame");
+  }
+
+  void OnPreCull() {
+    if (!Cardboard.SDK.VRModeEnabled || !Cardboard.SDK.UpdateState()) {
+      // Nothing to do.
+      return;
+    }
+
+    // Turn off the mono camera so it doesn't waste time rendering.
+    // Note: mono camera is left on from beginning of frame till now
+    // in order that other game logic (e.g. Camera.main) continues
+    // to work as expected.
+    GetComponent<Camera>().enabled = false;
+
+    // Render the eyes under our control.
+    foreach (var eye in Eyes) {
+      eye.Render();
+    }
+
+    // Remember to reenable
+    renderedStereo = true;
+  }
+
+  IEnumerator EndOfFrame() {
+    while (true) {
+      // If *we* turned off the mono cam, turn it back on for next frame.
+      if (renderedStereo) {
+        GetComponent<Camera>().enabled = true;
+        renderedStereo = false;
+      }
+      yield return new WaitForEndOfFrame();
+    }
+  }
+
+  void OnDestroy() {
+    StopCoroutine("EndOfFrame");
+  }
+}

--- a/Cardboard/Scripts/StereoController.cs.meta
+++ b/Cardboard/Scripts/StereoController.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: b6788e8e1b3f7447db6657ef0959d3ce
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cardboard/Scripts/StereoLensFlare.cs
+++ b/Cardboard/Scripts/StereoLensFlare.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using UnityEngine;
+using System.Collections;
+
+// Replacement for directional lens flares in stereo, which like skyboxes
+// (see SkyboxMesh.cs) do not consider the separation of the eyes.
+// Attach this script to a positional lens flare to create a stereo-
+// aware directional flare.  It keeps the flare positioned away well from
+// the camera along its own forward vector.
+[RequireComponent(typeof(LensFlare))]
+public class StereoLensFlare : MonoBehaviour {
+  [Tooltip("Fraction of the camera's far clip distance " +
+           "at which to position the flare.")]
+  [Range(0,1)]
+  public float range = 0.75f;
+
+  // Position the flare relative to the camera about to render it.
+  void OnWillRenderObject() {
+    transform.position = Camera.current.transform.position -
+                         range * Camera.current.farClipPlane * transform.forward;
+  }
+}

--- a/Cardboard/Scripts/StereoLensFlare.cs.meta
+++ b/Cardboard/Scripts/StereoLensFlare.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 8c99539c899ef4de09438c9a626c0c91
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fix deprecated warning about using shadowCastingMode instead of castShadows which results in the following warning: 

Assets/GoogleCardboard/Cardboard/Scripts/SkyboxMesh.cs(69,12): error CS0029: Cannot implicitly convert type `string' to `UnityEngine.Rendering.ShadowCastingMode'