### PR TITLE
Fixed infinite recursion in CardboardAudioSource clip accessor

### DIFF
--- a/Cardboard/Scripts/Audio/CardboardAudioSource.cs
+++ b/Cardboard/Scripts/Audio/CardboardAudioSource.cs
@@ -45,7 +45,7 @@ public class CardboardAudioSource : MonoBehaviour {
 
   /// The default AudioClip to play.
   public AudioClip clip {
-    get { return clip; }
+    get { return sourceClip; }
     set {
       sourceClip = value;
       if (audioSource != null) {


### PR DESCRIPTION
Infinite recursive call / stack overflow when attempting to access the clip of a CardboardAudioSource.

This accessor is useful when working with streamed or generative audio, where calling AudioClip.SetData() may be required.